### PR TITLE
Feature atomic singly linked list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,13 @@ add_executable(Relativistic_Hash_Table
 	${CMAKE_CURRENT_SOURCE_DIR}/Relativistic_Hash_Table/LibSource/RCU.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/Relativistic_Hash_Table/LibSource/RCUHashTable.cpp
 
+	${CMAKE_CURRENT_SOURCE_DIR}/Relativistic_Hash_Table/LibSource/include/RCUTypes.h
 	${CMAKE_CURRENT_SOURCE_DIR}/Relativistic_Hash_Table/LibSource/include/RCUApi.h
 	${CMAKE_CURRENT_SOURCE_DIR}/Relativistic_Hash_Table/LibSource/include/RCUHashTableApi.h
 	${CMAKE_CURRENT_SOURCE_DIR}/Relativistic_Hash_Table/LibSource/include/RCUHashTableCoreApi.h
 	${CMAKE_CURRENT_SOURCE_DIR}/Relativistic_Hash_Table/LibSource/include/RCUHashTableTypes.h
-	${CMAKE_CURRENT_SOURCE_DIR}/Relativistic_Hash_Table/LibSource/include/RCUTypes.h
+	${CMAKE_CURRENT_SOURCE_DIR}/Relativistic_Hash_Table/LibSource/include/AtomicSinglyLinkedListTypes.h
+	${CMAKE_CURRENT_SOURCE_DIR}/Relativistic_Hash_Table/LibSource/include/AtomicSinglyLinkedListApi.h
 
 	${CMAKE_CURRENT_SOURCE_DIR}/Relativistic_Hash_Table/TestsAndExamples/RCUTableTests.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/Relativistic_Hash_Table/TestsAndExamples/RCUTableTests.h

--- a/Relativistic_Hash_Table/.clang-format
+++ b/Relativistic_Hash_Table/.clang-format
@@ -1,0 +1,29 @@
+---
+BasedOnStyle: Google
+UseTab: Always
+AlignAfterOpenBracket: 'AlwaysBreak'
+AllowAllConstructorInitializersOnNextLine: 'false'
+AllowAllParametersOfDeclarationOnNextLine: 'false'
+AlignConsecutiveMacros: 'true'
+AllowShortCaseLabelsOnASingleLine: 'true'
+AllowShortFunctionsOnASingleLine: 'None'
+AllowShortIfStatementsOnASingleLine: 'Never'
+AllowShortLoopsOnASingleLine: 'false'
+BreakBeforeBraces: Allman
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+Cpp11BracedListStyle: 'false'
+ColumnLimit: 100
+NamespaceIndentation: Inner
+SpaceAfterTemplateKeyword: 'false'
+SpaceBeforeCtorInitializerColon: 'true'
+SpaceBeforeInheritanceColon: 'true'
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: 'true'
+SpaceInEmptyBlock: true
+Standard: 'Latest'
+
+IndentWidth: 2
+TabWidth: 2
+
+...

--- a/Relativistic_Hash_Table/LibSource/RCU.cpp
+++ b/Relativistic_Hash_Table/LibSource/RCU.cpp
@@ -1,5 +1,5 @@
-// Minimum_Userspace_RCU.cpp : This file contains the 'main' function. Program execution begins and
-// ends there.
+// Minimum_Userspace_RCU.cpp : This file contains the 'main' function. Program
+// execution begins and ends there.
 //
 #include <atomic>
 #include <thread>
@@ -45,7 +45,8 @@ bool rcuRegisterReaderThread()
 		return false;	 // already registered
 	auto bucketId = RCUReaderThreadRegistry::nextBucketId++;
 	if (bucketId >= RCUReaderThreadRegistry::nrNonOverlappingBucketCount)
-		return false;	 // too many threads already registered, fail this registration
+		return false;	 // too many threads already registered, fail this
+									 // registration
 	RCUReaderThreadRegistry::tlsReaderBucketId = bucketId;
 	return true;
 }
@@ -100,7 +101,8 @@ int64_t rcuReadLock(RCUZone& zone)
 	auto threadBucketId = fetchThreadBucketId(zone);
 	while (true)
 	{
-		// use relaxed here since we are going to do the acquire for the revalidation
+		// use relaxed here since we are going to do the acquire for the
+		// revalidation
 		int64_t epochId = zone.epochLatest.load(std::memory_order_relaxed);
 		auto epochRowId = epochId & c_epochMask;
 		std::atomic<int>& count = zone.epochsRing[epochRowId].pBuckets[threadBucketId].count;

--- a/Relativistic_Hash_Table/LibSource/RCU.cpp
+++ b/Relativistic_Hash_Table/LibSource/RCU.cpp
@@ -1,146 +1,150 @@
-// Minimum_Userspace_RCU.cpp : This file contains the 'main' function. Program execution begins and ends there.
+// Minimum_Userspace_RCU.cpp : This file contains the 'main' function. Program execution begins and
+// ends there.
 //
 #include <atomic>
 #include <thread>
 
-#include "RCUTypes.h"
 #include "RCUApi.h"
+#include "RCUTypes.h"
 
 namespace yrcu
 {
-    namespace
-    {
-        std::hash<std::thread::id> threadIdHasher;
+namespace
+{
+	std::hash<std::thread::id> threadIdHasher;
 
-        uint32_t upperBoundPowerOf2(uint32_t v)
-        {
-            if (v == 0)
-                ++v;
-            v--;
-            v |= v >> 1;
-            v |= v >> 2;
-            v |= v >> 4;
-            v |= v >> 8;
-            v |= v >> 16;
-            v++;
-            return v;
-        }
+	uint32_t upperBoundPowerOf2(uint32_t v)
+	{
+		if (v == 0)
+			++v;
+		v--;
+		v |= v >> 1;
+		v |= v >> 2;
+		v |= v >> 4;
+		v |= v >> 8;
+		v |= v >> 16;
+		v++;
+		return v;
+	}
 
-        int nrBucketsPerEpoch(RCUZone& zone)
-        {
-            return zone.nrHashThreadBuckets + RCUReaderThreadRegistry::nrNonOverlappingBucketCount;
-        }
-    }
+	int nrBucketsPerEpoch(RCUZone& zone)
+	{
+		return zone.nrHashThreadBuckets + RCUReaderThreadRegistry::nrNonOverlappingBucketCount;
+	}
+}	 // namespace
 
-    std::atomic<int> RCUReaderThreadRegistry::nextBucketId = 0;
-    const int RCUReaderThreadRegistry::nrNonOverlappingBucketCount = static_cast<int>(upperBoundPowerOf2(std::thread::hardware_concurrency()));
-    thread_local int RCUReaderThreadRegistry::tlsReaderBucketId = -1;
+std::atomic<int> RCUReaderThreadRegistry::nextBucketId = 0;
+const int RCUReaderThreadRegistry::nrNonOverlappingBucketCount =
+		static_cast<int>(upperBoundPowerOf2(std::thread::hardware_concurrency()));
+thread_local int RCUReaderThreadRegistry::tlsReaderBucketId = -1;
 
-    //return if registration is successful
-    bool rcuRegisterReaderThread()
-    {
-        if (RCUReaderThreadRegistry::tlsReaderBucketId != -1)
-            return false; //already registered
-        auto bucketId = RCUReaderThreadRegistry::nextBucketId++;
-        if (bucketId >= RCUReaderThreadRegistry::nrNonOverlappingBucketCount)
-            return false; //too many threads already registered, fail this registration
-        RCUReaderThreadRegistry::tlsReaderBucketId = bucketId;
-        return true;
-    }
-
-    void rcuInitZoneWithBucketCounts(RCUZone& zone, uint32_t nrHashThreadBuckets)
-    {
-        if (nrHashThreadBuckets < 1)
-            nrHashThreadBuckets = 1;
-        zone.nrHashThreadBuckets = upperBoundPowerOf2(nrHashThreadBuckets);
-        const size_t nrBucketsOneEpoch = nrBucketsPerEpoch(zone);
-        const size_t nrTotalRefCounts = nrBucketsOneEpoch * c_maxEpoches;
-        RCUReaderRefCountBucket* pStart = new RCUReaderRefCountBucket[nrTotalRefCounts];
-        for (size_t i = 0; i < nrTotalRefCounts; ++i)
-            (pStart + i)->count.store(0);
-        for (auto iEpoch = 0; iEpoch < c_maxEpoches; ++iEpoch)
-            zone.epochsRing[iEpoch].pBuckets = pStart + iEpoch * nrBucketsOneEpoch;
-
-        zone.epochLatest = 0;
-        zone.epochOldest = 0;
-    }
-
-    void rcuInitZone(RCUZone& zone)
-    {
-        uint32_t nrHardwareConcurrency = std::thread::hardware_concurrency();
-        rcuInitZoneWithBucketCounts(zone, nrHardwareConcurrency * c_nrRCUBucketsPerHardwareThread);
-    }
-
-    void rcuReleaseZone(RCUZone& zone)
-    {
-        const size_t nrBucketsOneEpoch = nrBucketsPerEpoch(zone);
-        const size_t nrTotalRefCounts = nrBucketsOneEpoch * c_maxEpoches;
-        delete[](zone.epochsRing[0].pBuckets);
-        zone.epochsRing[0].pBuckets = nullptr;
-    }
-
-    namespace
-    {
-        int fetchThreadBucketId(RCUZone& zone)
-        {
-            if (RCUReaderThreadRegistry::tlsReaderBucketId != -1)
-                return RCUReaderThreadRegistry::tlsReaderBucketId;
-            //fetch by hashing thread id
-            auto hash = threadIdHasher(std::this_thread::get_id());
-            return RCUReaderThreadRegistry::nrNonOverlappingBucketCount + (int)(hash & (zone.nrHashThreadBuckets - 1));
-        }
-    }
-
-    //epoch is returned to be used for unlocking
-    int64_t rcuReadLock(RCUZone& zone)
-    {
-        auto threadBucketId = fetchThreadBucketId(zone);
-        while (true)
-        {
-            //use relaxed here since we are going to do the acquire for the revalidation
-            int64_t epochId = zone.epochLatest.load(std::memory_order_relaxed);
-            auto epochRowId = epochId & c_epochMask;
-            std::atomic<int>& count = zone.epochsRing[epochRowId].pBuckets[threadBucketId].count;
-            count.fetch_add(1, std::memory_order_acq_rel);
-
-            int64_t epochIdRevalidate = zone.epochLatest.load(std::memory_order_acquire);
-
-            if (epochIdRevalidate == epochId)
-                return epochId;
-            else
-            {
-                //writer updated the epoch after we firstly read out the epoch id
-                //revert the ref-count and 
-                count.fetch_add(-1, std::memory_order_relaxed);
-            }
-        }
-    }
-
-    void rcuReadUnlock(RCUZone& zone, int64_t epoch)
-    {
-        auto threadBucketId = fetchThreadBucketId(zone);
-        auto epochRowId = epoch & c_epochMask;
-        std::atomic<int>& count = zone.epochsRing[epochRowId].pBuckets[threadBucketId].count;
-        count.fetch_add(-1, std::memory_order_acq_rel);
-    }
-
-    void rcuSynchronize(RCUZone& zone)
-    {
-        auto lastEpoch = zone.epochLatest.fetch_add(1, std::memory_order_release);
-        //wait for all the other readers to finish
-        auto nrBucketsOneZone = nrBucketsPerEpoch(zone);
-        for (; zone.epochOldest <= lastEpoch; ++zone.epochOldest)
-        {
-            int64_t epochRowId = zone.epochOldest & c_epochMask;
-            for (int iBucket = 0; iBucket < nrBucketsOneZone; ++iBucket)
-                while (zone.epochsRing[epochRowId].pBuckets[iBucket].count.load(std::memory_order_acquire) > 0)
-                    continue;
-        }
-    }
-
-    RCUZone::~RCUZone()
-    {
-        if (epochsRing[0].pBuckets)
-            rcuReleaseZone(*this);
-    }
+// return if registration is successful
+bool rcuRegisterReaderThread()
+{
+	if (RCUReaderThreadRegistry::tlsReaderBucketId != -1)
+		return false;	 // already registered
+	auto bucketId = RCUReaderThreadRegistry::nextBucketId++;
+	if (bucketId >= RCUReaderThreadRegistry::nrNonOverlappingBucketCount)
+		return false;	 // too many threads already registered, fail this registration
+	RCUReaderThreadRegistry::tlsReaderBucketId = bucketId;
+	return true;
 }
+
+void rcuInitZoneWithBucketCounts(RCUZone& zone, uint32_t nrHashThreadBuckets)
+{
+	if (nrHashThreadBuckets < 1)
+		nrHashThreadBuckets = 1;
+	zone.nrHashThreadBuckets = upperBoundPowerOf2(nrHashThreadBuckets);
+	const size_t nrBucketsOneEpoch = nrBucketsPerEpoch(zone);
+	const size_t nrTotalRefCounts = nrBucketsOneEpoch * c_maxEpoches;
+	RCUReaderRefCountBucket* pStart = new RCUReaderRefCountBucket[nrTotalRefCounts];
+	for (size_t i = 0; i < nrTotalRefCounts; ++i)
+		(pStart + i)->count.store(0);
+	for (auto iEpoch = 0; iEpoch < c_maxEpoches; ++iEpoch)
+		zone.epochsRing[iEpoch].pBuckets = pStart + iEpoch * nrBucketsOneEpoch;
+
+	zone.epochLatest = 0;
+	zone.epochOldest = 0;
+}
+
+void rcuInitZone(RCUZone& zone)
+{
+	uint32_t nrHardwareConcurrency = std::thread::hardware_concurrency();
+	rcuInitZoneWithBucketCounts(zone, nrHardwareConcurrency * c_nrRCUBucketsPerHardwareThread);
+}
+
+void rcuReleaseZone(RCUZone& zone)
+{
+	const size_t nrBucketsOneEpoch = nrBucketsPerEpoch(zone);
+	const size_t nrTotalRefCounts = nrBucketsOneEpoch * c_maxEpoches;
+	delete[] (zone.epochsRing[0].pBuckets);
+	zone.epochsRing[0].pBuckets = nullptr;
+}
+
+namespace
+{
+	int fetchThreadBucketId(RCUZone& zone)
+	{
+		if (RCUReaderThreadRegistry::tlsReaderBucketId != -1)
+			return RCUReaderThreadRegistry::tlsReaderBucketId;
+		// fetch by hashing thread id
+		auto hash = threadIdHasher(std::this_thread::get_id());
+		return RCUReaderThreadRegistry::nrNonOverlappingBucketCount +
+					 (int)(hash & (zone.nrHashThreadBuckets - 1));
+	}
+}	 // namespace
+
+// epoch is returned to be used for unlocking
+int64_t rcuReadLock(RCUZone& zone)
+{
+	auto threadBucketId = fetchThreadBucketId(zone);
+	while (true)
+	{
+		// use relaxed here since we are going to do the acquire for the revalidation
+		int64_t epochId = zone.epochLatest.load(std::memory_order_relaxed);
+		auto epochRowId = epochId & c_epochMask;
+		std::atomic<int>& count = zone.epochsRing[epochRowId].pBuckets[threadBucketId].count;
+		count.fetch_add(1, std::memory_order_acq_rel);
+
+		int64_t epochIdRevalidate = zone.epochLatest.load(std::memory_order_acquire);
+
+		if (epochIdRevalidate == epochId)
+			return epochId;
+		else
+		{
+			// writer updated the epoch after we firstly read out the epoch id
+			// revert the ref-count and
+			count.fetch_add(-1, std::memory_order_relaxed);
+		}
+	}
+}
+
+void rcuReadUnlock(RCUZone& zone, int64_t epoch)
+{
+	auto threadBucketId = fetchThreadBucketId(zone);
+	auto epochRowId = epoch & c_epochMask;
+	std::atomic<int>& count = zone.epochsRing[epochRowId].pBuckets[threadBucketId].count;
+	count.fetch_add(-1, std::memory_order_acq_rel);
+}
+
+void rcuSynchronize(RCUZone& zone)
+{
+	auto lastEpoch = zone.epochLatest.fetch_add(1, std::memory_order_release);
+	// wait for all the other readers to finish
+	auto nrBucketsOneZone = nrBucketsPerEpoch(zone);
+	for (; zone.epochOldest <= lastEpoch; ++zone.epochOldest)
+	{
+		int64_t epochRowId = zone.epochOldest & c_epochMask;
+		for (int iBucket = 0; iBucket < nrBucketsOneZone; ++iBucket)
+			while (zone.epochsRing[epochRowId].pBuckets[iBucket].count.load(std::memory_order_acquire) >
+						 0)
+				continue;
+	}
+}
+
+RCUZone::~RCUZone()
+{
+	if (epochsRing[0].pBuckets)
+		rcuReleaseZone(*this);
+}
+}	 // namespace yrcu

--- a/Relativistic_Hash_Table/LibSource/RCUHashTable.cpp
+++ b/Relativistic_Hash_Table/LibSource/RCUHashTable.cpp
@@ -1,392 +1,406 @@
+#include <cassert>
+#include <thread>
+
 #include "include/RCUApi.h"
-#include "include/RCUApi.h"
-#include "include/RCUTypes.h"
 #include "include/RCUHashTableApi.h"
 #include "include/RCUHashTableCoreApi.h"
 #include "include/RCUHashTableTypes.h"
-#include <thread>
-#include <cassert>
+#include "include/RCUTypes.h"
 
 namespace yrcu
 {
-    namespace
-    {
-        uint32_t upperBoundPowerOf2(uint32_t v)
-        {
-            if (v == 0)
-                return 1;
-            v--;
-            v |= v >> 1;
-            v |= v >> 2;
-            v |= v >> 4;
-            v |= v >> 8;
-            v |= v >> 16;
-            v++;
-            return v;
-        }
+namespace
+{
+	uint32_t upperBoundPowerOf2(uint32_t v)
+	{
+		if (v == 0)
+			return 1;
+		v--;
+		v |= v >> 1;
+		v |= v >> 2;
+		v |= v >> 4;
+		v |= v >> 8;
+		v |= v >> 16;
+		v++;
+		return v;
+	}
 
-        RTableCore::BucketsInfo* allocateAndInitBuckets(size_t nrBucketsPowerOf2)
-        {
-            assert(nrBucketsPowerOf2 > 0);
-            //allocate buckets info and the buckets together, better cache perf
-            size_t allocSize = sizeof(RTableCore::BucketsInfo) + nrBucketsPowerOf2 * sizeof(RTableCore::Bucket);
-            void* p = malloc(allocSize);
+	RTableCore::BucketsInfo* allocateAndInitBuckets(size_t nrBucketsPowerOf2)
+	{
+		assert(nrBucketsPowerOf2 > 0);
+		// allocate buckets info and the buckets together, better cache perf
+		size_t allocSize =
+				sizeof(RTableCore::BucketsInfo) + nrBucketsPowerOf2 * sizeof(RTableCore::Bucket);
+		void* p = malloc(allocSize);
 
-            RTableCore::BucketsInfo* pBucketsInfo = new (p) RTableCore::BucketsInfo();
-            pBucketsInfo->nrBucketsPowerOf2 = nrBucketsPowerOf2;
+		RTableCore::BucketsInfo* pBucketsInfo = new (p) RTableCore::BucketsInfo();
+		pBucketsInfo->nrBucketsPowerOf2 = nrBucketsPowerOf2;
 
-            char* pBucketsChar = (char*)p + sizeof(RTableCore::BucketsInfo);
-            RTableCore::Bucket* pBuckets = new (pBucketsChar)RTableCore::Bucket[nrBucketsPowerOf2];
+		char* pBucketsChar = (char*)p + sizeof(RTableCore::BucketsInfo);
+		RTableCore::Bucket* pBuckets = new (pBucketsChar) RTableCore::Bucket[nrBucketsPowerOf2];
 
-            pBucketsInfo->pBuckets = pBuckets;
-            //seems that for some implemenation, we cannot assume atomic int is triavially constructable
-            //otherwise, we should just do a memset to 0;
-            for (int iBucket = 0; iBucket < nrBucketsPowerOf2; ++iBucket)
-                (pBuckets + iBucket)->list.next.store(nullptr, std::memory_order_release);
-            return pBucketsInfo;
-        }
+		pBucketsInfo->pBuckets = pBuckets;
+		// seems that for some implemenation, we cannot assume atomic int is
+		// triavially constructable otherwise, we should just do a memset to 0;
+		for (int iBucket = 0; iBucket < nrBucketsPowerOf2; ++iBucket)
+			(pBuckets + iBucket)->list.next.store(nullptr, std::memory_order_release);
+		return pBucketsInfo;
+	}
 
-        void destroyAndFreeBuckets(RTableCore::BucketsInfo* p)
-        {
-            static_assert(std::is_trivially_destructible_v<RTableCore::Bucket>);
-            static_assert(std::is_trivially_destructible_v<RTableCore::BucketsInfo>);
-            free(p);
-        }
+	void destroyAndFreeBuckets(RTableCore::BucketsInfo* p)
+	{
+		static_assert(std::is_trivially_destructible_v<RTableCore::Bucket>);
+		static_assert(std::is_trivially_destructible_v<RTableCore::BucketsInfo>);
+		free(p);
+	}
 
-        //pSrc0->next is pointing to the 0th element of the src0
-        //pSrc1->next is pointing to the 0th element of the src1
-        //pSrc and pSrc1 are not nullptr themselves
-        void shrinkTwoBucketsToOne(AtomicSingleHead* pSrc0, AtomicSingleHead* pSrc1, AtomicSingleHead* pDst)
-        {
-            AtomicSingleHead* pSrc0First = pSrc0->next.load(std::memory_order_relaxed);
-            AtomicSingleHead* pSrc1First = pSrc1->next.load(std::memory_order_relaxed);
+	// pSrc0->next is pointing to the 0th element of the src0
+	// pSrc1->next is pointing to the 0th element of the src1
+	// pSrc and pSrc1 are not nullptr themselves
+	void
+	shrinkTwoBucketsToOne(AtomicSingleHead* pSrc0, AtomicSingleHead* pSrc1, AtomicSingleHead* pDst)
+	{
+		AtomicSingleHead* pSrc0First = pSrc0->next.load(std::memory_order_relaxed);
+		AtomicSingleHead* pSrc1First = pSrc1->next.load(std::memory_order_relaxed);
 
-            //Splice list 1 onto the end of list 0, and then let pDst point to the first element of list 0.
-            //This would mean that we need to walk list 0 to find its tail.
-            //But we could skip that if list 1 is empty.
-            if (pSrc1First == nullptr)
-            {
-                pDst->next.store(pSrc0First, std::memory_order_release);
-                return;
-            }
+		// Splice list 1 onto the end of list 0, and then let pDst point to the
+		// first element of list 0. This would mean that we need to walk list 0 to
+		// find its tail. But we could skip that if list 1 is empty.
+		if (pSrc1First == nullptr)
+		{
+			pDst->next.store(pSrc0First, std::memory_order_release);
+			return;
+		}
 
-            //If list 0 is empty, we directly let the pDst point to the first element of list 1.
-            if (pSrc0First == nullptr)
-            {
-                pDst->next.store(pSrc1First, std::memory_order_release);
-                return;
-            }
+		// If list 0 is empty, we directly let the pDst point to the first element
+		// of list 1.
+		if (pSrc0First == nullptr)
+		{
+			pDst->next.store(pSrc1First, std::memory_order_release);
+			return;
+		}
 
-            //search so that p is the last element of src0
-            AtomicSingleHead* pSrc0Last = pSrc0First;
-            while (true)
-            {
-                AtomicSingleHead* pNext = pSrc0Last->next.load(std::memory_order_relaxed);
-                if (pNext == nullptr)
-                    break;
-                pSrc0Last = pNext;
-            }
+		// search so that p is the last element of src0
+		AtomicSingleHead* pSrc0Last = pSrc0First;
+		while (true)
+		{
+			AtomicSingleHead* pNext = pSrc0Last->next.load(std::memory_order_relaxed);
+			if (pNext == nullptr)
+				break;
+			pSrc0Last = pNext;
+		}
 
-            pSrc0Last->next.store(pSrc1First, std::memory_order_release);
-            pDst->next.store(pSrc0First, std::memory_order_release);
-        }
+		pSrc0Last->next.store(pSrc1First, std::memory_order_release);
+		pDst->next.store(pSrc0First, std::memory_order_release);
+	}
 
-        size_t computeHashBucketId(AtomicSingleHead* p, size_t hashMask)
-        {
-            return YJ_CONTAINER_OF(p, RNode, head)->hash & hashMask;
-        }
+	size_t computeHashBucketId(AtomicSingleHead* p, size_t hashMask)
+	{
+		return YJ_CONTAINER_OF(p, RNode, head)->hash & hashMask;
+	}
 
-        //caller should make sure that pZipStart->next is not null
-        void unzipOneSegment(AtomicSingleHead* pZipStart, size_t hashMaskExpanded)
-        {
-            //pZipStart.next points to an element whose next has a different expanded hash bucket
-            // 
-            //An example old hash bucket's element chain(4 segments):
-            //|--seg0--|  |--Seg1--|  |--Seg2--|  |--Seg3---|
-            // x   x  X    y y  y Y    x  x   x    y y y y y
-            //(All x or X above will hash to the same expanded hash bucket.)
-            //(All y or Y above will hash to the same expanded hash bucket.)
-            //
-            //Before this function pZipStart->next points to X (jumpStart, last element of seg0)
-            //and yyyY(Seg1) are guaranteed to be reached from readers starting from a correct expanded hash bucket.
-            //            
-            //After this function pZipStart->next points to Y (newJumpStart, end of seg1) and X->next points to the first x of seg2.
-            //Thus yyyY is "unzipped"
-            //
-            //After this function, the caller needs to call rcuSynchronize() to ensure that all the readers reading
-            //xxx(seg2) is doing so through a correct expanded hash bucket
-            //(otherwise, since some reader looking for elements in seg2 might be still traversing seg1, next unzip to let
-            // Y to point to first y in Seg3 will make these readers not reaching what they want)
-            AtomicSingleHead* pJumpStart = pZipStart->next.load(std::memory_order_relaxed);
-            assert(pJumpStart && "Caller should rule out");
-            assert(pJumpStart->next.load(std::memory_order_relaxed) && "caller should rule out");
-            size_t jumpStartHashBucketId = computeHashBucketId(pJumpStart, hashMaskExpanded);
-            AtomicSingleHead* pNextJumpStart = pJumpStart->next.load(std::memory_order_relaxed);
-            AtomicSingleHead* pNext;
-            assert(computeHashBucketId(pNextJumpStart, hashMaskExpanded) != jumpStartHashBucketId);
-            while (true)
-            {
-                pNext = pNextJumpStart->next.load(std::memory_order_relaxed);
-                if (pNext == nullptr)
-                {
-                    //no more unzip needed for current bucket
-                    pNextJumpStart = nullptr;
-                    break;
-                }
-                if (computeHashBucketId(pNext, hashMaskExpanded) == jumpStartHashBucketId)
-                    break; //zip target found
-                pNextJumpStart = pNext;
-            }
-            pZipStart->next.store(pNextJumpStart, std::memory_order_release);
-            pJumpStart->next.store(pNext, std::memory_order_release);
-        }
+	// caller should make sure that pZipStart->next is not null
+	void unzipOneSegment(AtomicSingleHead* pZipStart, size_t hashMaskExpanded)
+	{
+		// pZipStart.next points to an element whose next has a different expanded
+		// hash bucket
+		//
+		// An example old hash bucket's element chain(4 segments):
+		//|--seg0--|  |--Seg1--|  |--Seg2--|  |--Seg3---|
+		//  x   x  X    y y  y Y    x  x   x    y y y y y
+		//(All x or X above will hash to the same expanded hash bucket.)
+		//(All y or Y above will hash to the same expanded hash bucket.)
+		//
+		// Before this function pZipStart->next points to X (jumpStart, last element
+		// of seg0) and yyyY(Seg1) are guaranteed to be reached from readers
+		// starting from a correct expanded hash bucket.
+		//
+		// After this function pZipStart->next points to Y (newJumpStart, end of
+		// seg1) and X->next points to the first x of seg2. Thus yyyY is "unzipped"
+		//
+		// After this function, the caller needs to call rcuSynchronize() to ensure
+		// that all the readers reading xxx(seg2) is doing so through a correct
+		// expanded hash bucket (otherwise,
+		// since some reader looking for elements in seg2 might be still traversing
+		// seg1, next unzip to let
+		//  Y to point to first y in Seg3 will make these readers not reaching what
+		//  they want)
+		AtomicSingleHead* pJumpStart = pZipStart->next.load(std::memory_order_relaxed);
+		assert(pJumpStart && "Caller should rule out");
+		assert(pJumpStart->next.load(std::memory_order_relaxed) && "caller should rule out");
+		size_t jumpStartHashBucketId = computeHashBucketId(pJumpStart, hashMaskExpanded);
+		AtomicSingleHead* pNextJumpStart = pJumpStart->next.load(std::memory_order_relaxed);
+		AtomicSingleHead* pNext;
+		assert(computeHashBucketId(pNextJumpStart, hashMaskExpanded) != jumpStartHashBucketId);
+		while (true)
+		{
+			pNext = pNextJumpStart->next.load(std::memory_order_relaxed);
+			if (pNext == nullptr)
+			{
+				// no more unzip needed for current bucket
+				pNextJumpStart = nullptr;
+				break;
+			}
+			if (computeHashBucketId(pNext, hashMaskExpanded) == jumpStartHashBucketId)
+				break;	// zip target found
+			pNextJumpStart = pNext;
+		}
+		pZipStart->next.store(pNextJumpStart, std::memory_order_release);
+		pJumpStart->next.store(pNext, std::memory_order_release);
+	}
 
-        //initialize initial two dst buckets corresponds to one src bucket
-        void initTwinDstBuckets(
-            RTableCore::Bucket* pSrc,
-            RTableCore::Bucket* pDst0,
-            RTableCore::Bucket* pDst1,
-            size_t bucketDstId0,
-            size_t bucketDstId1,
-            size_t bucketIdMask
-        )
-        {
-            AtomicSingleHead* pFirstDst0 = nullptr;
-            AtomicSingleHead* pFirstDst1 = nullptr;
-            for (auto p = pSrc->list.next.load(std::memory_order_relaxed); p != nullptr; p = p->next.load(std::memory_order_relaxed))
-            {
-                auto bucketId = computeHashBucketId(p, bucketIdMask);
-                assert(bucketId == bucketDstId0 || bucketId == bucketDstId1);
+	// initialize initial two dst buckets corresponds to one src bucket
+	void initTwinDstBuckets(
+			RTableCore::Bucket* pSrc,
+			RTableCore::Bucket* pDst0,
+			RTableCore::Bucket* pDst1,
+			size_t bucketDstId0,
+			size_t bucketDstId1,
+			size_t bucketIdMask)
+	{
+		AtomicSingleHead* pFirstDst0 = nullptr;
+		AtomicSingleHead* pFirstDst1 = nullptr;
+		for (auto p = pSrc->list.next.load(std::memory_order_relaxed); p != nullptr;
+				 p = p->next.load(std::memory_order_relaxed))
+		{
+			auto bucketId = computeHashBucketId(p, bucketIdMask);
+			assert(bucketId == bucketDstId0 || bucketId == bucketDstId1);
 
-                if (!pFirstDst0 && bucketId == bucketDstId0)
-                    pFirstDst0 = p;
-                else if (!pFirstDst1 && bucketId == bucketDstId1)
-                    pFirstDst1 = p;
+			if (!pFirstDst0 && bucketId == bucketDstId0)
+				pFirstDst0 = p;
+			else if (!pFirstDst1 && bucketId == bucketDstId1)
+				pFirstDst1 = p;
 
-                if (pFirstDst0 && pFirstDst1)
-                    break;
-            }
-            pDst0->list.next.store(pFirstDst0, std::memory_order_release);
-            pDst1->list.next.store(pFirstDst1, std::memory_order_release);
-        }
+			if (pFirstDst0 && pFirstDst1)
+				break;
+		}
+		pDst0->list.next.store(pFirstDst0, std::memory_order_release);
+		pDst1->list.next.store(pFirstDst1, std::memory_order_release);
+	}
 
-        //caller should make sure that pSrc->list.next is not null
-        bool findFirstUnzipPoint(RTableCore::Bucket* pSrc, size_t hashMask)
-        {
-            AtomicSingleHead* p = pSrc->list.next.load(std::memory_order_relaxed);
-            size_t hashBucketInitial = computeHashBucketId(p, hashMask);
-            while (true)
-            {
-                AtomicSingleHead* pNext = p->next.load(std::memory_order_relaxed);
-                if (pNext == nullptr)
-                {
-                    //no more unzip needed for current bucket
-                    p = nullptr;
-                    break;
-                }
-                if (computeHashBucketId(pNext, hashMask) != hashBucketInitial)
-                    break; //zip target found
-                p = pNext;
-            }
-            pSrc->list.next.store(p, std::memory_order_release);
-            return p;
-        }
+	// caller should make sure that pSrc->list.next is not null
+	bool findFirstUnzipPoint(RTableCore::Bucket* pSrc, size_t hashMask)
+	{
+		AtomicSingleHead* p = pSrc->list.next.load(std::memory_order_relaxed);
+		size_t hashBucketInitial = computeHashBucketId(p, hashMask);
+		while (true)
+		{
+			AtomicSingleHead* pNext = p->next.load(std::memory_order_relaxed);
+			if (pNext == nullptr)
+			{
+				// no more unzip needed for current bucket
+				p = nullptr;
+				break;
+			}
+			if (computeHashBucketId(pNext, hashMask) != hashBucketInitial)
+				break;	// zip target found
+			p = pNext;
+		}
+		pSrc->list.next.store(p, std::memory_order_release);
+		return p;
+	}
 
-        //returns if all finished
-        bool findFirstUnzipStarts(RTableCore::BucketsInfo* bucketsInfoOld, size_t bucketMaskNew)
-        {
-            bool allFinished = true;
-            for (size_t iHalf = 0; iHalf < bucketsInfoOld->nrBucketsPowerOf2; ++iHalf)
-            {
-                RTableCore::Bucket* pSrc = bucketsInfoOld->pBuckets + iHalf;
-                if (pSrc->list.next.load(std::memory_order_relaxed) != nullptr)
-                {
-                    bool needUnzip = findFirstUnzipPoint(pSrc, bucketMaskNew);
-                    if (needUnzip)
-                        allFinished = false;
-                }
-            }
+	// returns if all finished
+	bool findFirstUnzipStarts(RTableCore::BucketsInfo* bucketsInfoOld, size_t bucketMaskNew)
+	{
+		bool allFinished = true;
+		for (size_t iHalf = 0; iHalf < bucketsInfoOld->nrBucketsPowerOf2; ++iHalf)
+		{
+			RTableCore::Bucket* pSrc = bucketsInfoOld->pBuckets + iHalf;
+			if (pSrc->list.next.load(std::memory_order_relaxed) != nullptr)
+			{
+				bool needUnzip = findFirstUnzipPoint(pSrc, bucketMaskNew);
+				if (needUnzip)
+					allFinished = false;
+			}
+		}
 
-            if (allFinished)
-                return bucketsInfoOld;
-            return allFinished;
-        }
+		if (allFinished)
+			return bucketsInfoOld;
+		return allFinished;
+	}
 
-        void unzip(RTableCore::BucketsInfo* bucketsInfoOld, size_t bucketMaskNew, RCUZone& rcuZone)
-        {
-            while (true)
-            {
-                bool allFinished = true;
-                for (size_t iHalf = 0; iHalf < bucketsInfoOld->nrBucketsPowerOf2; ++iHalf)
-                {
-                    RTableCore::Bucket* pSrc = bucketsInfoOld->pBuckets + iHalf;
-                    if (pSrc->list.next.load(std::memory_order_relaxed) != nullptr)
-                    {
-                        allFinished = false;
-                        unzipOneSegment(&pSrc->list, bucketMaskNew);
-                    }
-                }
-                if (allFinished)
-                    break;
-                rcuSynchronize(rcuZone);
-            }
-        }
+	void unzip(RTableCore::BucketsInfo* bucketsInfoOld, size_t bucketMaskNew, RCUZone& rcuZone)
+	{
+		while (true)
+		{
+			bool allFinished = true;
+			for (size_t iHalf = 0; iHalf < bucketsInfoOld->nrBucketsPowerOf2; ++iHalf)
+			{
+				RTableCore::Bucket* pSrc = bucketsInfoOld->pBuckets + iHalf;
+				if (pSrc->list.next.load(std::memory_order_relaxed) != nullptr)
+				{
+					allFinished = false;
+					unzipOneSegment(&pSrc->list, bucketMaskNew);
+				}
+			}
+			if (allFinished)
+				break;
+			rcuSynchronize(rcuZone);
+		}
+	}
 
-        RTableCore::BucketsInfo* expandBucketsByFac2ReturnOld(RTableCore& table, RCUZone& zone)
-        {
-            auto* bucketsInfoOld = table.pBucketsInfo.load(std::memory_order_relaxed);
-            size_t nrBucketsOld = bucketsInfoOld->nrBucketsPowerOf2;
-            size_t nrBucketsNew = nrBucketsOld * 2;
-            size_t bucketMaskNew = nrBucketsNew - 1;
-            RTableCore::BucketsInfo* bucketsInfo = allocateAndInitBuckets(nrBucketsNew);
-            for (size_t iHalf = 0; iHalf < nrBucketsOld; ++iHalf)
-            {
-                RTableCore::Bucket* pSrc = bucketsInfoOld->pBuckets + iHalf;
-                RTableCore::Bucket* dst0 = bucketsInfo->pBuckets + iHalf;
-                size_t iSecondHalf = iHalf + nrBucketsOld;
-                RTableCore::Bucket* dst1 = bucketsInfo->pBuckets + iSecondHalf;
-                initTwinDstBuckets(pSrc, dst0, dst1, iHalf, iSecondHalf, bucketMaskNew);
-            }
+	RTableCore::BucketsInfo* expandBucketsByFac2ReturnOld(RTableCore& table, RCUZone& zone)
+	{
+		auto* bucketsInfoOld = table.pBucketsInfo.load(std::memory_order_relaxed);
+		size_t nrBucketsOld = bucketsInfoOld->nrBucketsPowerOf2;
+		size_t nrBucketsNew = nrBucketsOld * 2;
+		size_t bucketMaskNew = nrBucketsNew - 1;
+		RTableCore::BucketsInfo* bucketsInfo = allocateAndInitBuckets(nrBucketsNew);
+		for (size_t iHalf = 0; iHalf < nrBucketsOld; ++iHalf)
+		{
+			RTableCore::Bucket* pSrc = bucketsInfoOld->pBuckets + iHalf;
+			RTableCore::Bucket* dst0 = bucketsInfo->pBuckets + iHalf;
+			size_t iSecondHalf = iHalf + nrBucketsOld;
+			RTableCore::Bucket* dst1 = bucketsInfo->pBuckets + iSecondHalf;
+			initTwinDstBuckets(pSrc, dst0, dst1, iHalf, iSecondHalf, bucketMaskNew);
+		}
 
-            //publish new buckets info
-            table.pBucketsInfo.store(bucketsInfo, std::memory_order_release);
-            //synchronize so that no one is reading the old buckets
-            //since we are going to use the old buckets for unzipping
-            rcuSynchronize(zone);
+		// publish new buckets info
+		table.pBucketsInfo.store(bucketsInfo, std::memory_order_release);
+		// synchronize so that no one is reading the old buckets
+		// since we are going to use the old buckets for unzipping
+		rcuSynchronize(zone);
 
-            bool noNeedToUnzip = findFirstUnzipStarts(bucketsInfoOld, bucketMaskNew);
-            if (noNeedToUnzip)
-                return bucketsInfoOld;
+		bool noNeedToUnzip = findFirstUnzipStarts(bucketsInfoOld, bucketMaskNew);
+		if (noNeedToUnzip)
+			return bucketsInfoOld;
 
-            unzip(bucketsInfoOld, bucketMaskNew, zone);
-            return bucketsInfoOld;
-        }
+		unzip(bucketsInfoOld, bucketMaskNew, zone);
+		return bucketsInfoOld;
+	}
 
-        RTableCore::BucketsInfo* shrinkBucketsByFac2ReturnOld(RTableCore& table, RCUZone& rcuZone)
-        {
-            auto* bucketsInfoOld = table.pBucketsInfo.load(std::memory_order_relaxed);
-            size_t nrBucketsOld = bucketsInfoOld->nrBucketsPowerOf2;
-            size_t nrBucketsNew = nrBucketsOld / 2;
-            if (nrBucketsNew == 0)
-                return nullptr;
-            size_t bucketMask = nrBucketsNew - 1;
-            RTableCore::BucketsInfo* bucketsInfoNew = allocateAndInitBuckets(nrBucketsNew);
-            for (size_t iHalf = 0; iHalf < nrBucketsNew; ++iHalf)
-            {
-                RTableCore::Bucket* pDst = bucketsInfoNew->pBuckets + iHalf;
-                RTableCore::Bucket* pSrc0 = bucketsInfoOld->pBuckets + iHalf;
-                size_t iSecondHalf = iHalf + nrBucketsNew;
-                RTableCore::Bucket* pSrc1 = bucketsInfoOld->pBuckets + iSecondHalf;
-                shrinkTwoBucketsToOne(&pSrc0->list, &pSrc1->list, &pDst->list);
-            }
-            table.pBucketsInfo.store(bucketsInfoNew, std::memory_order_release);
-            rcuSynchronize(rcuZone);
-            return bucketsInfoOld;
-        }
-    }
+	RTableCore::BucketsInfo* shrinkBucketsByFac2ReturnOld(RTableCore& table, RCUZone& rcuZone)
+	{
+		auto* bucketsInfoOld = table.pBucketsInfo.load(std::memory_order_relaxed);
+		size_t nrBucketsOld = bucketsInfoOld->nrBucketsPowerOf2;
+		size_t nrBucketsNew = nrBucketsOld / 2;
+		if (nrBucketsNew == 0)
+			return nullptr;
+		size_t bucketMask = nrBucketsNew - 1;
+		RTableCore::BucketsInfo* bucketsInfoNew = allocateAndInitBuckets(nrBucketsNew);
+		for (size_t iHalf = 0; iHalf < nrBucketsNew; ++iHalf)
+		{
+			RTableCore::Bucket* pDst = bucketsInfoNew->pBuckets + iHalf;
+			RTableCore::Bucket* pSrc0 = bucketsInfoOld->pBuckets + iHalf;
+			size_t iSecondHalf = iHalf + nrBucketsNew;
+			RTableCore::Bucket* pSrc1 = bucketsInfoOld->pBuckets + iSecondHalf;
+			shrinkTwoBucketsToOne(&pSrc0->list, &pSrc1->list, &pDst->list);
+		}
+		table.pBucketsInfo.store(bucketsInfoNew, std::memory_order_release);
+		rcuSynchronize(rcuZone);
+		return bucketsInfoOld;
+	}
+}	 // namespace
 
-    void rTableCoreInitDetailed(RTableCore& table, const RTableCoreConfig& conf)
-    {
-        auto nrBucketsPowerOf2 = upperBoundPowerOf2(conf.nrBuckets);
-        RTableCore::BucketsInfo* bucketsInfo = allocateAndInitBuckets(nrBucketsPowerOf2);
-        table.expandFactor = conf.expandFactor;
-        table.shrinkFactor = conf.shrinkFactor;
-        table.pBucketsInfo.store(bucketsInfo, std::memory_order_relaxed);
-    }
-
-    void rTableInitDetailed(RTable& table, const RTableConfig& conf)
-    {
-        rcuInitZoneWithBucketCounts(table.rcuZone, conf.nrRcuBucketsForUnregisteredThreads);
-        RTableCoreConfig confCore;
-        confCore.expandFactor = conf.expandFactor;
-        confCore.nrBuckets = conf.nrBuckets;
-        confCore.shrinkFactor = conf.shrinkFactor;
-        rTableCoreInitDetailed(table.core, confCore);
-    }
-
-    void rTableInit(RTable& table, int nrBuckets)
-    {
-        auto nrThreadsBuckets = std::thread::hardware_concurrency() * 64;
-        RTableConfig conf;
-        conf.nrBuckets = nrBuckets;
-        conf.nrRcuBucketsForUnregisteredThreads = nrThreadsBuckets;
-        rTableInitDetailed(table, conf);
-    }
-
-    //can only be called if the user is sure that no dup exists
-    void rTableCoreInsertNoExpand(RTableCore& table, RNode* pEntry)
-    {
-        RTableCore::BucketsInfo* pBucketsInfo = table.pBucketsInfo.load(std::memory_order_relaxed);
-        auto bucketMask = pBucketsInfo->nrBucketsPowerOf2 - 1;
-        size_t bucketId = pEntry->hash & bucketMask;
-        RTableCore::Bucket* pBucket = pBucketsInfo->pBuckets + bucketId;
-        pEntry->head.next.store(pBucket->list.next, std::memory_order_release);
-        pBucket->list.next.store(&pEntry->head, std::memory_order_release);
-        table.size.fetch_add(1, std::memory_order_relaxed);
-    }
-
-    int64_t rTableReadLock(RTable& table)
-    {
-        return rcuReadLock(table.rcuZone);
-    }
-
-
-    void rTableReadUnlock(RTable& table, int64_t epoch)
-    {
-        rcuReadUnlock(table.rcuZone, epoch);
-    }
-
-
-    void rTableSynchronize(RTable& table)
-    {
-        rcuSynchronize(table.rcuZone);
-    }
-
-    void rTableCoreExpandBuckets2x(RTableCore& table, RCUZone& zone)
-    {
-        auto pOldInfo = expandBucketsByFac2ReturnOld(table, zone);
-        destroyAndFreeBuckets(pOldInfo);
-    }
-
-    void rTableExpandBuckets2x(RTable& table)
-    {
-        rTableCoreExpandBuckets2x(table.core, table.rcuZone);
-    }
-
-    bool rTableCoreShrinkBuckets2x(RTableCore& table, RCUZone& zone)
-    {
-        auto pOldInfo = shrinkBucketsByFac2ReturnOld(table, zone);
-        if (!pOldInfo)
-            return false;
-        destroyAndFreeBuckets(pOldInfo);
-        return true;
-    }
-
-    bool rTableShrinkBuckets2x(RTable& table)
-    {
-        return rTableCoreShrinkBuckets2x(table.core, table.rcuZone);
-    }
-
-    RTableCore::~RTableCore()
-    {
-        auto* p = pBucketsInfo.load();
-        if (p)
-            destroyAndFreeBuckets(p);
-    }
-
-    namespace rTableCoreDetail
-    {
-        void expandBucketsByFac2IfNecessary(size_t nrElements, size_t nrBuckets, RTableCore& table, RCUZone& zone)
-        {
-            if ((float)nrElements > table.expandFactor * float(nrBuckets))
-                rTableCoreExpandBuckets2x(table, zone);
-        }
-
-        bool shrinkBucketsByFac2IfNecessary(size_t nrElements, size_t nrBuckets, RTableCore& table, RCUZone& zone)
-        {
-            if ((float)nrElements < table.shrinkFactor * float(nrBuckets) && nrElements > 128)
-                return rTableCoreShrinkBuckets2x(table, zone);
-            return false;
-        }
-    }
+void rTableCoreInitDetailed(RTableCore& table, const RTableCoreConfig& conf)
+{
+	auto nrBucketsPowerOf2 = upperBoundPowerOf2(conf.nrBuckets);
+	RTableCore::BucketsInfo* bucketsInfo = allocateAndInitBuckets(nrBucketsPowerOf2);
+	table.expandFactor = conf.expandFactor;
+	table.shrinkFactor = conf.shrinkFactor;
+	table.pBucketsInfo.store(bucketsInfo, std::memory_order_relaxed);
 }
+
+void rTableInitDetailed(RTable& table, const RTableConfig& conf)
+{
+	rcuInitZoneWithBucketCounts(table.rcuZone, conf.nrRcuBucketsForUnregisteredThreads);
+	RTableCoreConfig confCore;
+	confCore.expandFactor = conf.expandFactor;
+	confCore.nrBuckets = conf.nrBuckets;
+	confCore.shrinkFactor = conf.shrinkFactor;
+	rTableCoreInitDetailed(table.core, confCore);
+}
+
+void rTableInit(RTable& table, int nrBuckets)
+{
+	auto nrThreadsBuckets = std::thread::hardware_concurrency() * 64;
+	RTableConfig conf;
+	conf.nrBuckets = nrBuckets;
+	conf.nrRcuBucketsForUnregisteredThreads = nrThreadsBuckets;
+	rTableInitDetailed(table, conf);
+}
+
+// can only be called if the user is sure that no dup exists
+void rTableCoreInsertNoExpand(RTableCore& table, RNode* pEntry)
+{
+	RTableCore::BucketsInfo* pBucketsInfo = table.pBucketsInfo.load(std::memory_order_relaxed);
+	auto bucketMask = pBucketsInfo->nrBucketsPowerOf2 - 1;
+	size_t bucketId = pEntry->hash & bucketMask;
+	RTableCore::Bucket* pBucket = pBucketsInfo->pBuckets + bucketId;
+	pEntry->head.next.store(pBucket->list.next, std::memory_order_release);
+	pBucket->list.next.store(&pEntry->head, std::memory_order_release);
+	table.size.fetch_add(1, std::memory_order_relaxed);
+}
+
+int64_t rTableReadLock(RTable& table)
+{
+	return rcuReadLock(table.rcuZone);
+}
+
+void rTableReadUnlock(RTable& table, int64_t epoch)
+{
+	rcuReadUnlock(table.rcuZone, epoch);
+}
+
+void rTableSynchronize(RTable& table)
+{
+	rcuSynchronize(table.rcuZone);
+}
+
+void rTableCoreExpandBuckets2x(RTableCore& table, RCUZone& zone)
+{
+	auto pOldInfo = expandBucketsByFac2ReturnOld(table, zone);
+	destroyAndFreeBuckets(pOldInfo);
+}
+
+void rTableExpandBuckets2x(RTable& table)
+{
+	rTableCoreExpandBuckets2x(table.core, table.rcuZone);
+}
+
+bool rTableCoreShrinkBuckets2x(RTableCore& table, RCUZone& zone)
+{
+	auto pOldInfo = shrinkBucketsByFac2ReturnOld(table, zone);
+	if (!pOldInfo)
+		return false;
+	destroyAndFreeBuckets(pOldInfo);
+	return true;
+}
+
+bool rTableShrinkBuckets2x(RTable& table)
+{
+	return rTableCoreShrinkBuckets2x(table.core, table.rcuZone);
+}
+
+RTableCore::~RTableCore()
+{
+	auto* p = pBucketsInfo.load();
+	if (p)
+		destroyAndFreeBuckets(p);
+}
+
+namespace rTableCoreDetail
+{
+	void expandBucketsByFac2IfNecessary(
+			size_t nrElements,
+			size_t nrBuckets,
+			RTableCore& table,
+			RCUZone& zone)
+	{
+		if ((float)nrElements > table.expandFactor * float(nrBuckets))
+			rTableCoreExpandBuckets2x(table, zone);
+	}
+
+	bool shrinkBucketsByFac2IfNecessary(
+			size_t nrElements,
+			size_t nrBuckets,
+			RTableCore& table,
+			RCUZone& zone)
+	{
+		if ((float)nrElements < table.shrinkFactor * float(nrBuckets) && nrElements > 128)
+			return rTableCoreShrinkBuckets2x(table, zone);
+		return false;
+	}
+}	 // namespace rTableCoreDetail
+}	 // namespace yrcu

--- a/Relativistic_Hash_Table/LibSource/include/AtomicSinglyLinkedListApi.h
+++ b/Relativistic_Hash_Table/LibSource/include/AtomicSinglyLinkedListApi.h
@@ -1,8 +1,7 @@
 #include "AtomicSinglyLinkedListTypes.h"
 
-#define YJ_OFFSET_OF(Type, Field) __builtin_offsetof(Type, Field)
-#define YJ_CONTAINER_OF(ptr, type, member) \
-	((type*)((char*)ptr - YJ_OFFSET_OF(type, member)))
+#define YJ_OFFSET_OF(Type, Field)					 __builtin_offsetof(Type, Field)
+#define YJ_CONTAINER_OF(ptr, type, member) ((type*)((char*)ptr - YJ_OFFSET_OF(type, member)))
 
 namespace yrcu
 {
@@ -37,12 +36,9 @@ inline void atomicSlistInsertFront(AtomicSingleHead* list, AtomicSingleHead* ele
 // UnaryPredict is of signature `bool(AtomicSingleHead*)`.
 // If none is find, nullptr is returned
 template<typename UnaryPredict>
-AtomicSingleHead* atomicSlistFindIf(
-		AtomicSingleHead* list,
-		UnaryPredict predict)
+AtomicSingleHead* atomicSlistFindIf(AtomicSingleHead* list, UnaryPredict predict)
 {
-	for (AtomicSingleHead* p = list->next.load(std::memory_order_acquire);
-			 p != nullptr;
+	for (AtomicSingleHead* p = list->next.load(std::memory_order_acquire); p != nullptr;
 			 p = p->next.load(std::memory_order_acquire))
 		if (predict(p))
 			return p;
@@ -51,9 +47,7 @@ AtomicSingleHead* atomicSlistFindIf(
 
 // Try find the first element inside
 template<typename UnaryPredict>
-AtomicSingleHead* atomicSlistRemoveIf(
-		AtomicSingleHead* list,
-		UnaryPredict predict)
+AtomicSingleHead* atomicSlistRemoveIf(AtomicSingleHead* list, UnaryPredict predict)
 {
 	AtomicSingleHead* pLast = list;
 	AtomicSingleHead* p = pLast->next.load(std::memory_order_relaxed);
@@ -61,8 +55,7 @@ AtomicSingleHead* atomicSlistRemoveIf(
 	{
 		if (predict(p))
 		{
-			pLast->next.store(
-					p->next.load(std::memory_order_relaxed), std::memory_order_release);
+			pLast->next.store(p->next.load(std::memory_order_relaxed), std::memory_order_release);
 			break;
 		}
 		pLast = p;
@@ -73,9 +66,7 @@ AtomicSingleHead* atomicSlistRemoveIf(
 
 // Head will be returned if it exists in the list
 // Otherwise, nullptr is returned
-inline AtomicSingleHead* atomicSlistRemove(
-		AtomicSingleHead* list,
-		AtomicSingleHead* head)
+inline AtomicSingleHead* atomicSlistRemove(AtomicSingleHead* list, AtomicSingleHead* head)
 {
 	AtomicSingleHead* pLast = list;
 	AtomicSingleHead* p = pLast->next.load(std::memory_order_relaxed);
@@ -84,8 +75,7 @@ inline AtomicSingleHead* atomicSlistRemove(
 	{
 		if (p == head)
 		{
-			pLast->next.store(
-					p->next.load(std::memory_order_relaxed), std::memory_order_release);
+			pLast->next.store(p->next.load(std::memory_order_relaxed), std::memory_order_release);
 			break;
 		}
 		pLast = p;

--- a/Relativistic_Hash_Table/LibSource/include/AtomicSinglyLinkedListApi.h
+++ b/Relativistic_Hash_Table/LibSource/include/AtomicSinglyLinkedListApi.h
@@ -1,0 +1,97 @@
+#include "AtomicSinglyLinkedListTypes.h"
+
+#define YJ_OFFSET_OF(Type, Field) __builtin_offsetof(Type, Field)
+#define YJ_CONTAINER_OF(ptr, type, member) \
+	((type*)((char*)ptr - YJ_OFFSET_OF(type, member)))
+
+namespace yrcu
+{
+//*************** Atomic singly list **************//
+// Write operations (insert and erase) must be serialized, and the atomic singly
+// linked list itself does not require any rcu synchronization.
+//
+// External RCU synchronization is only required if there are readers who wants
+// to read elements and there are writers who wants to destruct the element
+// after the unlinking of element. If the erased (here it means that it is only
+// unlinked but not yet destroyed).
+
+inline void atomicSlistInit(AtomicSingleHead* list)
+{
+	// no memory orders since initialization should never be executing in parallel
+	// with other apis
+	list->next.store(nullptr, std::memory_order_relaxed);
+}
+
+// Write operation(must be serialized with other write operations)
+// link elem to the front of the list
+inline void atomicSlistInsertFront(AtomicSingleHead* list, AtomicSingleHead* elem)
+{
+	// Since writers are serialized, inside writing apis we load atomic with
+	// mem-order-relaxed. But since there might be concurrent readers, inside
+	// writing apis we store with mem-order-release.
+	AtomicSingleHead* pNext = list->next.load(std::memory_order_relaxed);
+	elem->next.store(pNext, std::memory_order_release);
+}
+
+// Find first element that predict(AtomicSingleHead*) returns true.
+// UnaryPredict is of signature `bool(AtomicSingleHead*)`.
+// If none is find, nullptr is returned
+template<typename UnaryPredict>
+AtomicSingleHead* atomicSlistFindIf(
+		AtomicSingleHead* list,
+		UnaryPredict predict)
+{
+	for (AtomicSingleHead* p = list->next.load(std::memory_order_acquire);
+			 p != nullptr;
+			 p = p->next.load(std::memory_order_acquire))
+		if (predict(p))
+			return p;
+	return nullptr;
+}
+
+// Try find the first element inside
+template<typename UnaryPredict>
+AtomicSingleHead* atomicSlistRemoveIf(
+		AtomicSingleHead* list,
+		UnaryPredict predict)
+{
+	AtomicSingleHead* pLast = list;
+	AtomicSingleHead* p = pLast->next.load(std::memory_order_relaxed);
+	while (p)
+	{
+		if (predict(p))
+		{
+			pLast->next.store(
+					p->next.load(std::memory_order_relaxed), std::memory_order_release);
+			break;
+		}
+		pLast = p;
+		p = p->next.load(std::memory_order_relaxed);
+	}
+	return p;
+}
+
+// Head will be returned if it exists in the list
+// Otherwise, nullptr is returned
+inline AtomicSingleHead* atomicSlistRemove(
+		AtomicSingleHead* list,
+		AtomicSingleHead* head)
+{
+	AtomicSingleHead* pLast = list;
+	AtomicSingleHead* p = pLast->next.load(std::memory_order_relaxed);
+
+	while (p)
+	{
+		if (p == head)
+		{
+			pLast->next.store(
+					p->next.load(std::memory_order_relaxed), std::memory_order_release);
+			break;
+		}
+		pLast = p;
+		p = p->next.load(std::memory_order_relaxed);
+	}
+	return p;
+}
+
+}	 // namespace yrcu

--- a/Relativistic_Hash_Table/LibSource/include/AtomicSinglyLinkedListTypes.h
+++ b/Relativistic_Hash_Table/LibSource/include/AtomicSinglyLinkedListTypes.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <atomic>
+
+namespace yrcu
+{
+    struct AtomicSingleHead
+    {
+        std::atomic<AtomicSingleHead*> next;
+    };
+}

--- a/Relativistic_Hash_Table/LibSource/include/AtomicSinglyLinkedListTypes.h
+++ b/Relativistic_Hash_Table/LibSource/include/AtomicSinglyLinkedListTypes.h
@@ -4,8 +4,8 @@
 
 namespace yrcu
 {
-    struct AtomicSingleHead
-    {
-        std::atomic<AtomicSingleHead*> next;
-    };
-}
+struct AtomicSingleHead
+{
+	std::atomic<AtomicSingleHead*> next;
+};
+}	 // namespace yrcu

--- a/Relativistic_Hash_Table/LibSource/include/RCUApi.h
+++ b/Relativistic_Hash_Table/LibSource/include/RCUApi.h
@@ -2,53 +2,53 @@
 #include <cstdint>
 namespace yrcu
 {
-    //An RCU zone is a rcu synchronization unit.
-    //For a particular rcu zone, the reader calls rcuReadLock and rcuReadUnlock to 
-    //make a reader side critical session.
-    //The writer calls rcuSynchronize to ensure that any ongoing readers' critical session
-    //started from the call expires.
-    //The writer can then safely garbage collect resources.
-    //
-    //The scope of the protection of RCUZone can be freely defined by the user.
-    //
-    //Nested locking for RCUZones, it is not allowed to nest read-lock or call rcuSynchronize
-    //on a single RCUZone. Different RCUZones can be nest read-locked and rcuSynchronized.
-    //But it might trigger a deadlock. 
-    // The same rule/validation to avoid deadlock as mutex applies: 
-    // rcu-readLock/unlock() is equivalent to mutex-readLock/readUnlock
-    // rcuSynchronize() is equivalent to mutex-write-lock and then immediately mutex-write-unlock.
-    struct RCUZone;
+// An RCU zone is a rcu synchronization unit.
+// For a particular rcu zone, the reader calls rcuReadLock and rcuReadUnlock to
+// make a reader side critical session.
+// The writer calls rcuSynchronize to ensure that any ongoing readers' critical
+// session started from the call expires. The writer can then safely garbage
+// collect resources.
+//
+// The scope of the protection of RCUZone can be freely defined by the user.
+//
+// Nested locking for RCUZones, it is not allowed to nest read-lock or call
+// rcuSynchronize on a single RCUZone. Different RCUZones can be nest
+// read-locked and rcuSynchronized. But it might trigger a deadlock.
+//  The same rule/validation to avoid deadlock as mutex applies:
+//  rcu-readLock/unlock() is equivalent to mutex-readLock/readUnlock
+//  rcuSynchronize() is equivalent to mutex-write-lock and then immediately
+//  mutex-write-unlock.
+struct RCUZone;
 
-    //It is recommended (but not required) that reader threads register itself 
-    //globally before any RCUZone is initialized.
-    //Registered threads are guaranteed to have no contention with other readers. 
-    //(They have a unique bucket for its read count).
-    //Other threads that are not registered will have to share nrHashThreadBuckets
-    // buckets, dependent on the hashing of the thread id.
-    bool rcuRegisterReaderThread();
+// It is recommended (but not required) that reader threads register itself
+// globally before any RCUZone is initialized.
+// Registered threads are guaranteed to have no contention with other readers.
+//(They have a unique bucket for its read count).
+// Other threads that are not registered will have to share nrHashThreadBuckets
+//  buckets, dependent on the hashing of the thread id.
+bool rcuRegisterReaderThread();
 
+// Before any operation on the rcuZone, the
+// Init rcu zone with a specified nrHashThreadBuckets to be shared
+// for all unregistered threads who will read lock the rcu zone.
+void rcuInitZoneWithBucketCounts(RCUZone& zone, uint32_t nrHashThreadBuckets);
 
-    //Before any operation on the rcuZone, the
-    //Init rcu zone with a specified nrHashThreadBuckets to be shared
-    //for all unregistered threads who will read lock the rcu zone.
-    void rcuInitZoneWithBucketCounts(RCUZone& zone, uint32_t nrHashThreadBuckets);
+// Similar to rcuInitZoneWithBucketCounts(RCUZone& zone, uint32_t
+// nrHashThreadBuckets); nrHashThreadsBuckets is configured as a multiple factor
+// of hardware_concurrency. factor is c_nrBucketsPerHardwareThread
+constexpr size_t c_nrRCUBucketsPerHardwareThread = 64;
+void rcuInitZone(RCUZone& zone);
 
-    //Similar to rcuInitZoneWithBucketCounts(RCUZone& zone, uint32_t nrHashThreadBuckets);
-    //nrHashThreadsBuckets is configured as a multiple factor of hardware_concurrency.
-    //factor is c_nrBucketsPerHardwareThread
-    constexpr size_t c_nrRCUBucketsPerHardwareThread = 64;
-    void rcuInitZone(RCUZone& zone);
-    
-    //After the usage of rcuZone, it must be released.
-    void rcuReleaseZone(RCUZone& zone);
+// After the usage of rcuZone, it must be released.
+void rcuReleaseZone(RCUZone& zone);
 
-    //reader critical session start
-    int64_t rcuReadLock(RCUZone& zone);
+// reader critical session start
+int64_t rcuReadLock(RCUZone& zone);
 
-    //reader critical session end
-    void rcuReadUnlock(RCUZone& zone, int64_t epoch);
+// reader critical session end
+void rcuReadUnlock(RCUZone& zone, int64_t epoch);
 
-    //writer to wait for all on going reader critical sessions 
-    //before the call to expire
-    void rcuSynchronize(RCUZone& zone);
-}
+// writer to wait for all on going reader critical sessions
+// before the call to expire
+void rcuSynchronize(RCUZone& zone);
+}	 // namespace yrcu

--- a/Relativistic_Hash_Table/LibSource/include/RCUHashTableApi.h
+++ b/Relativistic_Hash_Table/LibSource/include/RCUHashTableApi.h
@@ -1,120 +1,125 @@
 #pragma once
-#include "RCUHashTableTypes.h"
-#include "RCUHashTableCoreApi.h"
 #include "RCUApi.h"
+#include "RCUHashTableCoreApi.h"
+#include "RCUHashTableTypes.h"
 
 namespace yrcu
 {
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    //--------------------------Advanced API-------------------------------------------------//
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    struct RTableConfig
-    {
-        int nrBuckets = 64;
-        int nrRcuBucketsForUnregisteredThreads = 128;
-        float expandFactor = 1.1f;
-        float shrinkFactor = 0.25f;
-    };
+//////////////////////////////////////////////////////////////
+//--------------------------Advanced API--------------------//
+//////////////////////////////////////////////////////////////
+struct RTableConfig
+{
+	int nrBuckets = 64;
+	int nrRcuBucketsForUnregisteredThreads = 128;
+	float expandFactor = 1.1f;
+	float shrinkFactor = 0.25f;
+};
 
-    void rTableInitDetailed(RTable& table, const RTableConfig& conf);
+void rTableInitDetailed(RTable& table, const RTableConfig& conf);
 
-    //Op is of function signature of bool(RNode* p0), which returns if the entry is what you are looking
-    //try erase but no synchronize
-    //This enables the caller to do several rTableTryDetach operations, do one rTableSynchronize and then
-    //do all the garbage collections.
-    template<typename UnaryPredicate>
-    RNode* rTableTryDetachNoShrink(RTable& table, size_t hashVal, UnaryPredicate matchOp)
-    {
-        rTableCoreCoreTryDetachNoShrink(table.core, hashVal, std::move(matchOp));
-    }
-
-    //might shrink automatically
-    //But will not do any synchronization
-    template<typename Op>
-    RNode* rTableTryDetachAutoShrink(RTable& table, size_t hashVal, Op matchOp, bool* outIfAlreadyRcuSynrhonized = nullptr)
-    {
-        return rTableCoreTryDetachAutoShrink(table.core, hashVal, matchOp, table.rcuZone, outIfAlreadyRcuSynrhonized);
-    }
-
-    template<typename Op>
-    bool rTableTryInsertNoExpand(RTable& table, RNode* pEntry, size_t hashVal, Op matchOp)
-    {
-        return rTableCoreTryInsertNoExpand(table.core, pEntry, hashVal, matchOp);
-    }
-
-    //it is allowed to have multiple detach before a single synchronize operation
-    //and after the synchronize operation, the detached nodes can be safely freed.
-    void rTableSynchronize(RTable& table);
-
-    //can only be called if the user is sure that no dup exists
-    void rTableInsertNoExpand(RTable& table, RNode* pEntry);
-
-    void rTableExpandBuckets2x(RTable& table);
-
-    bool rTableShrinkBuckets2x(RTable& table);
-
-    //-----------------------------------------------------------------------------------------------//
-
-
-    ///////////////////////////////////////////////////////////////////////////////////////////////////
-    //--------------------------------Basic API------------------------------------------------------//
-    ///////////////////////////////////////////////////////////////////////////////////////////////////
-    //hash table must be initialized, nrBuckets is advised to be bigger than the predicted element count
-    void rTableInit(RTable& table, int nrBuckets = 64);
-
-    //read lock and unlock creates a RCU read critical session
-    //the writer waits for all the critical sessions for the epoch to finish 
-    //before deleting the resource
-    //returns the epoch to be passed into the rTableReadUnlock
-    int64_t rTableReadLock(RTable& table);
-    void rTableReadUnlock(RTable& table, int64_t epoch);
-    struct RTableReadLockGuard
-    {
-        explicit RTableReadLockGuard(RTable& table) :tbl{ table }
-        {
-            epoch = rTableReadLock(table);
-        }
-        RTableReadLockGuard(const RTableReadLockGuard&) = delete;
-        RTableReadLockGuard(RTableReadLockGuard&&) = delete;
-        RTableReadLockGuard& operator=(const RTableReadLockGuard&) = delete;
-        RTableReadLockGuard& operator=(RTableReadLockGuard&&) = delete;
-
-        ~RTableReadLockGuard()
-        {
-            rTableReadUnlock(tbl, epoch);
-        }
-        RTable& tbl;
-        int64_t epoch = 0;
-    };
-
-    //Read operation
-    //\parameter hashVal should be the hash value of the find target, only table entries with a hash value equals to `hashVal` is checked for
-    // equality with matchOp.
-    //op should have function signature of bool(RNode*) to identify if the RNode equals to what is to be found
-    template<typename Op>
-    RNode* rTableFind(const RTable& table, size_t hashVal, Op matchOp)
-    {
-        return rTableCoreFind(table.core, hashVal, matchOp);
-    }
-
-    //Write operation: all writers must be serialized
-    //Op is of function signature of bool(RNode* p0, RcuHashTaleEntry* p1), which returns if
-    //two hash table entries are equivalent.
-    //Expand if necessary
-    template<typename Op>
-    bool rTableTryInsert(RTable& table, RNode* pEntry, size_t hashVal, Op matchOp)
-    {
-        return rTableCoreTryInsert(table.core, table.rcuZone, pEntry, hashVal, matchOp);
-    }
-
-    //Write operation: all writers must be serialized
-    //Op is of function signature of bool(RNode* p0), which returns if the entry is what you are looking
-    //for.
-    //rcuSynchronize is called internally and it is safe to delete resource of RNode.
-    template<typename Op>
-    RNode* rTableTryDetachAndSynchronize(RTable& table, size_t hashVal, Op matchOp)
-    {
-        return rTableCoreTryDetachAndSynchronize(table.core, table.rcuZone, hashVal, matchOp);
-    }
+// Op is of function signature of bool(RNode* p0), which returns if the entry is
+// what you are looking try erase but no synchronize This enables the caller to
+// do several rTableTryDetach operations, do one rTableSynchronize and then do
+// all the garbage collections.
+template<typename UnaryPredicate>
+RNode* rTableTryDetachNoShrink(RTable& table, size_t hashVal, UnaryPredicate matchOp)
+{
+	rTableCoreCoreTryDetachNoShrink(table.core, hashVal, std::move(matchOp));
 }
 
+// might shrink automatically
+// But will not do any synchronization
+template<typename Op>
+RNode* rTableTryDetachAutoShrink(
+		RTable& table,
+		size_t hashVal,
+		Op matchOp,
+		bool* outIfAlreadyRcuSynrhonized = nullptr)
+{
+	return rTableCoreTryDetachAutoShrink(
+			table.core, hashVal, matchOp, table.rcuZone, outIfAlreadyRcuSynrhonized);
+}
+
+template<typename Op>
+bool rTableTryInsertNoExpand(RTable& table, RNode* pEntry, size_t hashVal, Op matchOp)
+{
+	return rTableCoreTryInsertNoExpand(table.core, pEntry, hashVal, matchOp);
+}
+
+// it is allowed to have multiple detach before a single synchronize operation
+// and after the synchronize operation, the detached nodes can be safely freed.
+void rTableSynchronize(RTable& table);
+
+// can only be called if the user is sure that no dup exists
+void rTableInsertNoExpand(RTable& table, RNode* pEntry);
+
+void rTableExpandBuckets2x(RTable& table);
+
+bool rTableShrinkBuckets2x(RTable& table);
+
+//---------------------------------------------------------------------------//
+
+////////////////////////////////////////////////////////////////
+//--------------------------------Basic API-------------------//
+////////////////////////////////////////////////////////////////
+// hash table must be initialized, nrBuckets is advised to be bigger than the
+// predicted element count
+void rTableInit(RTable& table, int nrBuckets = 64);
+
+// read lock and unlock creates a RCU read critical session
+// the writer waits for all the critical sessions for the epoch to finish
+// before deleting the resource
+// returns the epoch to be passed into the rTableReadUnlock
+int64_t rTableReadLock(RTable& table);
+void rTableReadUnlock(RTable& table, int64_t epoch);
+struct RTableReadLockGuard
+{
+	explicit RTableReadLockGuard(RTable& table) : tbl{ table }
+	{
+		epoch = rTableReadLock(table);
+	}
+	RTableReadLockGuard(const RTableReadLockGuard&) = delete;
+	RTableReadLockGuard(RTableReadLockGuard&&) = delete;
+	RTableReadLockGuard& operator=(const RTableReadLockGuard&) = delete;
+	RTableReadLockGuard& operator=(RTableReadLockGuard&&) = delete;
+
+	~RTableReadLockGuard()
+	{
+		rTableReadUnlock(tbl, epoch);
+	}
+	RTable& tbl;
+	int64_t epoch = 0;
+};
+
+// Read operation
+//\parameter hashVal should be the hash value of the find target, only table
+// entries with a hash value equals to `hashVal` is checked for
+//  equality with matchOp.
+// op should have function signature of bool(RNode*) to identify if the RNode
+// equals to what is to be found
+template<typename Op>
+RNode* rTableFind(const RTable& table, size_t hashVal, Op matchOp)
+{
+	return rTableCoreFind(table.core, hashVal, matchOp);
+}
+
+// Write operation: all writers must be serialized
+// Op is of function signature of bool(RNode* p0, RcuHashTaleEntry* p1), which
+// returns if two hash table entries are equivalent. Expand if necessary
+template<typename Op>
+bool rTableTryInsert(RTable& table, RNode* pEntry, size_t hashVal, Op matchOp)
+{
+	return rTableCoreTryInsert(table.core, table.rcuZone, pEntry, hashVal, matchOp);
+}
+
+// Write operation: all writers must be serialized
+// Op is of function signature of bool(RNode* p0), which returns if the entry is
+// what you are looking for. rcuSynchronize is called internally and it is safe
+// to delete resource of RNode.
+template<typename Op>
+RNode* rTableTryDetachAndSynchronize(RTable& table, size_t hashVal, Op matchOp)
+{
+	return rTableCoreTryDetachAndSynchronize(table.core, table.rcuZone, hashVal, matchOp);
+}
+}	 // namespace yrcu

--- a/Relativistic_Hash_Table/LibSource/include/RCUHashTableCoreApi.h
+++ b/Relativistic_Hash_Table/LibSource/include/RCUHashTableCoreApi.h
@@ -32,31 +32,23 @@ struct RTableCoreConfig
 
 void rTableCoreInitDetailed(RTableCore& table, const RTableCoreConfig& conf);
 
-// Op is of function signature of bool(RNode* p0), which returns if the entry is
+// Op is of function signature of bool(const RNode* p0), which returns if the entry is
 // what you are looking try erase but no synchronize This enables the caller to
 // do several rcuHashTableTryDetach operations, do one rcuHashTableSynchronize
 // and then do all the garbage collections.
 template<typename UnaryPredicate>
-RNode* rTableCoreTryDetachNoShrink(RTableCore& table, size_t hashVal, UnaryPredicate matchOp)
+RNode* rTableCoreTryDetachNoShrink(RTableCore& table, size_t hashVal, UnaryPredicate predict)
 {
 	RTableCore::BucketsInfo* pBucketsInfo = table.pBucketsInfo.load(std::memory_order_acquire);
 	size_t bucketHash = pBucketsInfo->nrBucketsPowerOf2 - 1;
 	auto bucketId = hashVal & bucketHash;
 	RTableCore::Bucket* pBucket = pBucketsInfo->pBuckets + bucketId;
-	AtomicSingleHead* pLast = &pBucket->list;
-	for (AtomicSingleHead* p = pLast->next.load(std::memory_order_relaxed); p != nullptr;)
-	{
-		AtomicSingleHead* pNext = p->next.load(std::memory_order_relaxed);
-		RNode* pEntry = YJ_CONTAINER_OF(p, RNode, head);
-		if (pEntry->hash == hashVal && matchOp(pEntry))
-		{
-			pLast->next.store(pNext, std::memory_order_release);
-			return pEntry;
-		}
-		pLast = p;
-		p = pNext;
-	}
-	return nullptr;
+	auto predictInner = [&predict](const AtomicSingleHead* p)
+	{ return predict(YJ_CONTAINER_OF(p, RNode, head)); };
+	AtomicSingleHead* pRemoved = atomicSlistRemoveIf(&pBucket->list, predictInner);
+	if (!pRemoved)
+		return nullptr;
+	return YJ_CONTAINER_OF(pRemoved, RNode, head);
 }
 
 // might shrink automatically
@@ -88,29 +80,24 @@ RNode* rTableCoreTryDetachAutoShrink(
 	}
 }
 
-template<typename Op>
-bool rTableCoreTryInsertNoExpand(RTableCore& table, RNode* pEntry, size_t hashVal, Op matchOp)
+template<typename BinaryPredict>
+bool rTableCoreTryInsertNoExpand(
+		RTableCore& table,
+		RNode* pEntry,
+		size_t hashVal,
+		BinaryPredict binaryPredict)
 {
 	pEntry->hash = hashVal;
 	RTableCore::BucketsInfo* pBucketsInfo = table.pBucketsInfo.load(std::memory_order_relaxed);
 	size_t bucketMask = pBucketsInfo->nrBucketsPowerOf2 - 1;
 	auto bucketId = pEntry->hash & bucketMask;
 	RTableCore::Bucket* pBucket = pBucketsInfo->pBuckets + bucketId;
-	AtomicSingleHead* pFirst = pBucket->list.next.load(std::memory_order_relaxed);
-	AtomicSingleHead* p;
-	for (p = pFirst; p != nullptr; p = p->next.load(std::memory_order_relaxed))
-	{
-		RNode* pEntryExisting = YJ_CONTAINER_OF(p, RNode, head);
-		if (pEntry->hash == pEntryExisting->hash && matchOp(pEntry, pEntryExisting))
-			break;
-	}
-	if (p != nullptr)
-		return false;
-	// put the new element in the front
-	pEntry->head.next.store(pFirst, std::memory_order_release);
-	pBucket->list.next.store(&pEntry->head, std::memory_order_release);
-	table.size.fetch_add(1, std::memory_order_relaxed);
-	return true;
+	auto binaryPredictInner = [&binaryPredict](const AtomicSingleHead* p1, const AtomicSingleHead* p2)
+	{ return binaryPredict(YJ_CONTAINER_OF(p1, RNode, head), YJ_CONTAINER_OF(p2, RNode, head)); };
+	bool inserted = atomicSlistPrependIfNoMatch(&pBucket->list, &pEntry->head, binaryPredictInner);
+	if (inserted)
+		table.size.fetch_add(1, std::memory_order_relaxed);
+	return inserted;
 }
 
 // can only be called if the user is sure that no dup exists
@@ -136,21 +123,19 @@ void rTableCoreInit(RTableCore& table);
 //  equality with matchOp.
 // op should have function signature of bool(RNode*) to identify if the RNode
 // equals to what is to be found
-template<typename Op>
-RNode* rTableCoreFind(const RTableCore& table, size_t hashVal, Op matchOp)
+template<typename UnaryPrediction>
+RNode* rTableCoreFind(const RTableCore& table, size_t hashVal, UnaryPrediction predict)
 {
 	RTableCore::BucketsInfo* pBucketsInfo = table.pBucketsInfo.load(std::memory_order_acquire);
 	size_t bucketHash = pBucketsInfo->nrBucketsPowerOf2 - 1;
 	auto bucketId = hashVal & bucketHash;
 	RTableCore::Bucket* pBucket = pBucketsInfo->pBuckets + bucketId;
-	for (auto p = pBucket->list.next.load(std::memory_order_acquire); p != nullptr;
-			 p = p->next.load(std::memory_order_acquire))
-	{
-		RNode* pEntry = YJ_CONTAINER_OF(p, RNode, head);
-		if (pEntry->hash == hashVal && matchOp(pEntry))
-			return pEntry;
-	}
-	return nullptr;
+	auto predictInner = [&predict](const AtomicSingleHead* p)
+	{ return predict(YJ_CONTAINER_OF(p, RNode, head)); };
+	AtomicSingleHead* pFound = atomicSlistFindIf(&pBucket->list, predictInner);
+	if (!pFound)
+		return nullptr;
+	return YJ_CONTAINER_OF(pFound, RNode, head);
 }
 
 // Write operation: all writers must be serialized

--- a/Relativistic_Hash_Table/LibSource/include/RCUHashTableCoreApi.h
+++ b/Relativistic_Hash_Table/LibSource/include/RCUHashTableCoreApi.h
@@ -1,170 +1,193 @@
 #pragma once
-#include "RCUHashTableTypes.h"
+#include "AtomicSinglyLinkedListApi.h"
 #include "RCUApi.h"
+#include "RCUHashTableTypes.h"
 
 namespace yrcu
 {
-    namespace rTableCoreDetail
-    {
-        void expandBucketsByFac2IfNecessary(size_t nrElements, size_t nrBuckets, RTableCore& table, RCUZone& zone);
-        bool shrinkBucketsByFac2IfNecessary(size_t nrElements, size_t nrBuckets, RTableCore& table, RCUZone& zone);
-    }
+namespace rTableCoreDetail
+{
+	void expandBucketsByFac2IfNecessary(
+			size_t nrElements,
+			size_t nrBuckets,
+			RTableCore& table,
+			RCUZone& zone);
+	bool shrinkBucketsByFac2IfNecessary(
+			size_t nrElements,
+			size_t nrBuckets,
+			RTableCore& table,
+			RCUZone& zone);
+}	 // namespace rTableCoreDetail
 
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    //--------------------------Advanced API-------------------------------------------------//
-    ///////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////
+//         Advanced API
+/////////////////////////////////////////////
 
+struct RTableCoreConfig
+{
+	int nrBuckets = 64;
+	float expandFactor = 1.1f;
+	float shrinkFactor = 0.25f;
+};
 
-    struct RTableCoreConfig
-    {
-        int nrBuckets = 64;
-        float expandFactor = 1.1f;
-        float shrinkFactor = 0.25f;
-    };
+void rTableCoreInitDetailed(RTableCore& table, const RTableCoreConfig& conf);
 
-    void rTableCoreInitDetailed(RTableCore& table, const RTableCoreConfig& conf);
-
-    //Op is of function signature of bool(RNode* p0), which returns if the entry is what you are looking
-    //try erase but no synchronize
-    //This enables the caller to do several rcuHashTableTryDetach operations, do one rcuHashTableSynchronize and then
-    //do all the garbage collections.
-    template<typename UnaryPredicate>
-    RNode* rTableCoreTryDetachNoShrink(RTableCore& table, size_t hashVal, UnaryPredicate matchOp)
-    {
-        RTableCore::BucketsInfo* pBucketsInfo = table.pBucketsInfo.load(std::memory_order_acquire);
-        size_t bucketHash = pBucketsInfo->nrBucketsPowerOf2 - 1;
-        auto bucketId = hashVal & bucketHash;
-        RTableCore::Bucket* pBucket = pBucketsInfo->pBuckets + bucketId;
-        AtomicSingleHead* pLast = &pBucket->list;
-        for (AtomicSingleHead* p = pLast->next.load(std::memory_order_relaxed); p != nullptr;)
-        {
-            AtomicSingleHead* pNext = p->next.load(std::memory_order_relaxed);
-            RNode* pEntry = YJ_CONTAINER_OF(p, RNode, head);
-            if (pEntry->hash == hashVal && matchOp(pEntry))
-            {
-                pLast->next.store(pNext, std::memory_order_release);
-                return pEntry;
-            }
-            pLast = p;
-            p = pNext;
-        }
-        return nullptr;
-    }
-
-    //might shrink automatically
-    //But will not do any synchronization
-    template<typename Op>
-    RNode* rTableCoreTryDetachAutoShrink(RTableCore& table, size_t hashVal, Op matchOp, RCUZone& zone, bool* outIfAlreadyRcuSynrhonized = nullptr)
-    {
-        RNode* p = rTableCoreTryDetachNoShrink(table, hashVal, std::move(matchOp));
-        if (!p)
-        {
-            if (outIfAlreadyRcuSynrhonized)
-                *outIfAlreadyRcuSynrhonized = false;
-            return p;
-        }
-        else
-        {
-            size_t currentSize = table.size.load(std::memory_order_relaxed);
-            size_t nrBuckets = table.pBucketsInfo.load(std::memory_order_acquire)->nrBucketsPowerOf2;
-            bool ifAlreadyRcuSynrhonized = rTableCoreDetail::shrinkBucketsByFac2IfNecessary(currentSize, nrBuckets, table, zone);
-            if (outIfAlreadyRcuSynrhonized)
-                *outIfAlreadyRcuSynrhonized = ifAlreadyRcuSynrhonized;
-            return p;
-        }
-    }
-
-    template<typename Op>
-    bool rTableCoreTryInsertNoExpand(RTableCore& table, RNode* pEntry, size_t hashVal, Op matchOp)
-    {
-        pEntry->hash = hashVal;
-        RTableCore::BucketsInfo* pBucketsInfo = table.pBucketsInfo.load(std::memory_order_relaxed);
-        size_t bucketMask = pBucketsInfo->nrBucketsPowerOf2 - 1;
-        auto bucketId = pEntry->hash & bucketMask;
-        RTableCore::Bucket* pBucket = pBucketsInfo->pBuckets + bucketId;
-        AtomicSingleHead* pFirst = pBucket->list.next.load(std::memory_order_relaxed);
-        AtomicSingleHead* p;
-        for (p = pFirst; p != nullptr; p = p->next.load(std::memory_order_relaxed))
-        {
-            RNode* pEntryExisting = YJ_CONTAINER_OF(p, RNode, head);
-            if (pEntry->hash == pEntryExisting->hash && matchOp(pEntry, pEntryExisting))
-                break;
-        }
-        if (p != nullptr)
-            return false;
-        //put the new element in the front
-        pEntry->head.next.store(pFirst, std::memory_order_release);
-        pBucket->list.next.store(&pEntry->head, std::memory_order_release);
-        table.size.fetch_add(1, std::memory_order_relaxed);
-        return true;
-    }
-
-    //can only be called if the user is sure that no dup exists
-    void rTableCoreInsertNoExpand(RTableCore& table, RNode* pEntry);
-
-    void rTableCoreExpandBuckets2x(RTableCore& table, RCUZone& zone);
-
-    bool rTableCoreShrinkBuckets2x(RTableCore& table, RCUZone& zone);
-
-    //-----------------------------------------------------------------------------------------------//
-
-
-    ///////////////////////////////////////////////////////////////////////////////////////////////////
-    //--------------------------------Basic API------------------------------------------------------//
-    ///////////////////////////////////////////////////////////////////////////////////////////////////
-    //hash table must be initialized, nrBuckets is advised to be bigger than the predicted element count
-    void rTableCoreInit(RTableCore& table);
-
-    //Read operation
-    //\parameter hashVal should be the hash value of the find target, only table entries with a hash value equals to `hashVal` is checked for
-    // equality with matchOp.
-    //op should have function signature of bool(RNode*) to identify if the RNode equals to what is to be found
-    template<typename Op>
-    RNode* rTableCoreFind(const RTableCore& table, size_t hashVal, Op matchOp)
-    {
-        RTableCore::BucketsInfo* pBucketsInfo = table.pBucketsInfo.load(std::memory_order_acquire);
-        size_t bucketHash = pBucketsInfo->nrBucketsPowerOf2 - 1;
-        auto bucketId = hashVal & bucketHash;
-        RTableCore::Bucket* pBucket = pBucketsInfo->pBuckets + bucketId;
-        for (auto p = pBucket->list.next.load(std::memory_order_acquire); p != nullptr; p = p->next.load(std::memory_order_acquire))
-        {
-            RNode* pEntry = YJ_CONTAINER_OF(p, RNode, head);
-            if (pEntry->hash == hashVal && matchOp(pEntry))
-                return pEntry;
-        }
-        return nullptr;
-    }
-
-    //Write operation: all writers must be serialized
-    //Op is of function signature of bool(RNode* p0, RcuHashTaleEntry* p1), which returns if
-    //two hash table entries are equivalent.
-    //Expand if necessary
-    template<typename Op>
-    bool rTableCoreTryInsert(RTableCore& table, RCUZone& rcuZone, RNode* pEntry, size_t hashVal, Op matchOp)
-    {
-        bool inserted = rTableCoreTryInsertNoExpand(table, pEntry, hashVal, matchOp);
-        if (!inserted)
-            return false;
-        auto currentSize = table.size.load(std::memory_order_relaxed);
-        size_t nrBuckets = table.pBucketsInfo.load(std::memory_order_acquire)->nrBucketsPowerOf2;
-        rTableCoreDetail::expandBucketsByFac2IfNecessary(currentSize, nrBuckets, table, rcuZone);
-        return true;
-    }
-
-    //Write operation: all writers must be serialized
-    //Op is of function signature of bool(RNode* p0), which returns if the entry is what you are looking
-    //for.
-    //rcuSynchronize is called internally and it is safe to delete resource of RNode.
-    template<typename Op>
-    RNode* rTableCoreTryDetachAndSynchronize(RTableCore& table, RCUZone& rcuZone, size_t hashVal, Op matchOp)
-    {
-        bool ifAlreadyRcuSynchronized = false;
-        RNode* pEntry = rTableCoreTryDetachAutoShrink(table, hashVal, matchOp, rcuZone, &ifAlreadyRcuSynchronized);
-        if (pEntry == nullptr)
-            return pEntry;
-        if (!ifAlreadyRcuSynchronized)
-            rcuSynchronize(rcuZone);
-        return pEntry;
-    }
+// Op is of function signature of bool(RNode* p0), which returns if the entry is
+// what you are looking try erase but no synchronize This enables the caller to
+// do several rcuHashTableTryDetach operations, do one rcuHashTableSynchronize
+// and then do all the garbage collections.
+template<typename UnaryPredicate>
+RNode* rTableCoreTryDetachNoShrink(RTableCore& table, size_t hashVal, UnaryPredicate matchOp)
+{
+	RTableCore::BucketsInfo* pBucketsInfo = table.pBucketsInfo.load(std::memory_order_acquire);
+	size_t bucketHash = pBucketsInfo->nrBucketsPowerOf2 - 1;
+	auto bucketId = hashVal & bucketHash;
+	RTableCore::Bucket* pBucket = pBucketsInfo->pBuckets + bucketId;
+	AtomicSingleHead* pLast = &pBucket->list;
+	for (AtomicSingleHead* p = pLast->next.load(std::memory_order_relaxed); p != nullptr;)
+	{
+		AtomicSingleHead* pNext = p->next.load(std::memory_order_relaxed);
+		RNode* pEntry = YJ_CONTAINER_OF(p, RNode, head);
+		if (pEntry->hash == hashVal && matchOp(pEntry))
+		{
+			pLast->next.store(pNext, std::memory_order_release);
+			return pEntry;
+		}
+		pLast = p;
+		p = pNext;
+	}
+	return nullptr;
 }
 
+// might shrink automatically
+// But will not do any synchronization
+template<typename Op>
+RNode* rTableCoreTryDetachAutoShrink(
+		RTableCore& table,
+		size_t hashVal,
+		Op matchOp,
+		RCUZone& zone,
+		bool* outIfAlreadyRcuSynrhonized = nullptr)
+{
+	RNode* p = rTableCoreTryDetachNoShrink(table, hashVal, std::move(matchOp));
+	if (!p)
+	{
+		if (outIfAlreadyRcuSynrhonized)
+			*outIfAlreadyRcuSynrhonized = false;
+		return p;
+	}
+	else
+	{
+		size_t currentSize = table.size.load(std::memory_order_relaxed);
+		size_t nrBuckets = table.pBucketsInfo.load(std::memory_order_acquire)->nrBucketsPowerOf2;
+		bool ifAlreadyRcuSynrhonized =
+				rTableCoreDetail::shrinkBucketsByFac2IfNecessary(currentSize, nrBuckets, table, zone);
+		if (outIfAlreadyRcuSynrhonized)
+			*outIfAlreadyRcuSynrhonized = ifAlreadyRcuSynrhonized;
+		return p;
+	}
+}
+
+template<typename Op>
+bool rTableCoreTryInsertNoExpand(RTableCore& table, RNode* pEntry, size_t hashVal, Op matchOp)
+{
+	pEntry->hash = hashVal;
+	RTableCore::BucketsInfo* pBucketsInfo = table.pBucketsInfo.load(std::memory_order_relaxed);
+	size_t bucketMask = pBucketsInfo->nrBucketsPowerOf2 - 1;
+	auto bucketId = pEntry->hash & bucketMask;
+	RTableCore::Bucket* pBucket = pBucketsInfo->pBuckets + bucketId;
+	AtomicSingleHead* pFirst = pBucket->list.next.load(std::memory_order_relaxed);
+	AtomicSingleHead* p;
+	for (p = pFirst; p != nullptr; p = p->next.load(std::memory_order_relaxed))
+	{
+		RNode* pEntryExisting = YJ_CONTAINER_OF(p, RNode, head);
+		if (pEntry->hash == pEntryExisting->hash && matchOp(pEntry, pEntryExisting))
+			break;
+	}
+	if (p != nullptr)
+		return false;
+	// put the new element in the front
+	pEntry->head.next.store(pFirst, std::memory_order_release);
+	pBucket->list.next.store(&pEntry->head, std::memory_order_release);
+	table.size.fetch_add(1, std::memory_order_relaxed);
+	return true;
+}
+
+// can only be called if the user is sure that no dup exists
+void rTableCoreInsertNoExpand(RTableCore& table, RNode* pEntry);
+
+void rTableCoreExpandBuckets2x(RTableCore& table, RCUZone& zone);
+
+bool rTableCoreShrinkBuckets2x(RTableCore& table, RCUZone& zone);
+
+//-----------------------------------------------------------------------------------------------//
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Basic API
+///////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// hash table must be initialized, nrBuckets is advised to be bigger than the
+// predicted element count
+void rTableCoreInit(RTableCore& table);
+
+// Read operation
+//\parameter hashVal should be the hash value of the find target, only table
+// entries with a hash value equals to `hashVal` is checked for
+//  equality with matchOp.
+// op should have function signature of bool(RNode*) to identify if the RNode
+// equals to what is to be found
+template<typename Op>
+RNode* rTableCoreFind(const RTableCore& table, size_t hashVal, Op matchOp)
+{
+	RTableCore::BucketsInfo* pBucketsInfo = table.pBucketsInfo.load(std::memory_order_acquire);
+	size_t bucketHash = pBucketsInfo->nrBucketsPowerOf2 - 1;
+	auto bucketId = hashVal & bucketHash;
+	RTableCore::Bucket* pBucket = pBucketsInfo->pBuckets + bucketId;
+	for (auto p = pBucket->list.next.load(std::memory_order_acquire); p != nullptr;
+			 p = p->next.load(std::memory_order_acquire))
+	{
+		RNode* pEntry = YJ_CONTAINER_OF(p, RNode, head);
+		if (pEntry->hash == hashVal && matchOp(pEntry))
+			return pEntry;
+	}
+	return nullptr;
+}
+
+// Write operation: all writers must be serialized
+// Op is of function signature of bool(RNode* p0, RcuHashTaleEntry* p1), which
+// returns if two hash table entries are equivalent. Expand if necessary
+template<typename Op>
+bool rTableCoreTryInsert(
+		RTableCore& table,
+		RCUZone& rcuZone,
+		RNode* pEntry,
+		size_t hashVal,
+		Op matchOp)
+{
+	bool inserted = rTableCoreTryInsertNoExpand(table, pEntry, hashVal, matchOp);
+	if (!inserted)
+		return false;
+	auto currentSize = table.size.load(std::memory_order_relaxed);
+	size_t nrBuckets = table.pBucketsInfo.load(std::memory_order_acquire)->nrBucketsPowerOf2;
+	rTableCoreDetail::expandBucketsByFac2IfNecessary(currentSize, nrBuckets, table, rcuZone);
+	return true;
+}
+
+// Write operation: all writers must be serialized
+// Op is of function signature of bool(RNode* p0), which returns if the entry is
+// what you are looking for. rcuSynchronize is called internally and it is safe
+// to delete resource of RNode.
+template<typename Op>
+RNode*
+rTableCoreTryDetachAndSynchronize(RTableCore& table, RCUZone& rcuZone, size_t hashVal, Op matchOp)
+{
+	bool ifAlreadyRcuSynchronized = false;
+	RNode* pEntry =
+			rTableCoreTryDetachAutoShrink(table, hashVal, matchOp, rcuZone, &ifAlreadyRcuSynchronized);
+	if (pEntry == nullptr)
+		return pEntry;
+	if (!ifAlreadyRcuSynchronized)
+		rcuSynchronize(rcuZone);
+	return pEntry;
+}
+}	 // namespace yrcu

--- a/Relativistic_Hash_Table/LibSource/include/RCUHashTableTypes.h
+++ b/Relativistic_Hash_Table/LibSource/include/RCUHashTableTypes.h
@@ -1,48 +1,42 @@
 #pragma once
+#include "AtomicSinglyLinkedListTypes.h"
 #include "RCUTypes.h"
 namespace yrcu
 {
-#define YJ_OFFSET_OF(Type, Field) __builtin_offsetof(Type, Field)
-#define YJ_CONTAINER_OF(ptr, type, member) ((type*)((char*)ptr-YJ_OFFSET_OF(type, member)))
-    struct AtomicSingleHead
-    {
-        std::atomic<AtomicSingleHead*> next;
-    };
+struct RNode
+{
+	size_t hash;
+	AtomicSingleHead head;
+};
 
-    struct RNode
-    {
-        size_t hash;
-        AtomicSingleHead head;
-    };
+// RTableCore does not include the RCUZone and thus is feasible for shared RCUZone
+struct RTableCore
+{
+	~RTableCore();
 
-    //RTableCore does not include the RCUZone and thus is feasible for shared RCUZone
-    struct RTableCore
-    {
-        ~RTableCore();
+	std::atomic<size_t> size = 0;
+	struct Bucket
+	{
+		AtomicSingleHead list;
+	};
 
-        std::atomic<size_t> size = 0;
-        struct Bucket
-        {
-            AtomicSingleHead list;
-        };
+	struct BucketsInfo
+	{
+		size_t nrBucketsPowerOf2;
+		Bucket* pBuckets;
+	};
 
-        struct BucketsInfo
-        {
-            size_t nrBucketsPowerOf2;
-            Bucket* pBuckets;
-        };
+	// expand when element/buckets-count grows over this factor
+	float expandFactor = 256.f;
+	// shrink when element/buckets-count is less than this factor
+	float shrinkFactor = 8.f;
 
-        //expand when element/buckets-count grows over this factor
-        float expandFactor = 256.f;
-        //shrink when element/buckets-count is less than this factor
-        float shrinkFactor = 8.f;
+	std::atomic<BucketsInfo*> pBucketsInfo = nullptr;
+};
 
-        std::atomic<BucketsInfo*> pBucketsInfo = nullptr;
-    };
-
-    struct RTable
-    {
-        RTableCore core;
-        RCUZone rcuZone;
-    };
-}
+struct RTable
+{
+	RTableCore core;
+	RCUZone rcuZone;
+};
+}	 // namespace yrcu

--- a/Relativistic_Hash_Table/LibSource/include/RCUTypes.h
+++ b/Relativistic_Hash_Table/LibSource/include/RCUTypes.h
@@ -3,35 +3,35 @@
 
 namespace yrcu
 {
-    constexpr int c_maxEpoches = 2;
-    constexpr int c_epochMask = c_maxEpoches - 1;
+constexpr int c_maxEpoches = 2;
+constexpr int c_epochMask = c_maxEpoches - 1;
 
-    struct alignas(64) RCUReaderRefCountBucket
-    {
-        std::atomic<int> count;
-    };
+struct alignas(64) RCUReaderRefCountBucket
+{
+	std::atomic<int> count;
+};
 
-    struct EpochBuckets
-    {
-        RCUReaderRefCountBucket* pBuckets = nullptr;
-    };
+struct EpochBuckets
+{
+	RCUReaderRefCountBucket* pBuckets = nullptr;
+};
 
-    //There should be only one RCUGlobal globally 
-    //Upto hardware_concurrency threads could register themselves once on the RCUGlobal
-    struct RCUReaderThreadRegistry
-    {
-        static std::atomic<int> nextBucketId;
-        static const int nrNonOverlappingBucketCount;
-        static thread_local int tlsReaderBucketId;
-    };
-    
-    struct RCUZone
-    {
-        int nrHashThreadBuckets = 0;
-        EpochBuckets epochsRing[c_maxEpoches];
-        std::atomic<int64_t> epochLatest = 0;
-        int64_t epochOldest = 0;
+// There should be only one RCUGlobal globally
+// Upto hardware_concurrency threads could register themselves once on the RCUGlobal
+struct RCUReaderThreadRegistry
+{
+	static std::atomic<int> nextBucketId;
+	static const int nrNonOverlappingBucketCount;
+	static thread_local int tlsReaderBucketId;
+};
 
-        ~RCUZone();
-    };
-}
+struct RCUZone
+{
+	int nrHashThreadBuckets = 0;
+	EpochBuckets epochsRing[c_maxEpoches];
+	std::atomic<int64_t> epochLatest = 0;
+	int64_t epochOldest = 0;
+
+	~RCUZone();
+};
+}	 // namespace yrcu

--- a/Relativistic_Hash_Table/TestsAndExamples/RCUTableTests.cpp
+++ b/Relativistic_Hash_Table/TestsAndExamples/RCUTableTests.cpp
@@ -1,453 +1,456 @@
-#include "RCUHashTableApi.h"
-#include "TestHelper.h"
-#include <vector>
 #include <future>
 #include <iostream>
 #include <memory>
-#include <unordered_set>
 #include <shared_mutex>
+#include <unordered_set>
+#include <vector>
+
+#include "RCUHashTableApi.h"
+#include "TestHelper.h"
 
 namespace yrcu
 {
-    namespace
-    {
-        struct PerfComparisonWithStdUnorderedSet
-        {
-            static constexpr size_t c_nrElementsToLookUp = 2ull << 18;
-            static constexpr size_t c_nrRounds = 10;;
+namespace
+{
+	struct PerfComparisonWithStdUnorderedSet
+	{
+		static constexpr size_t c_nrElementsToLookUp = 2ull << 18;
+		static constexpr size_t c_nrRounds = 10;
 
-            template<typename TMutex, template<typename> typename TReadLock, bool readOnly>
-            void runStdUnorderedMapMutex(const std::string& title)
-            {
-                std::unordered_set<size_t> mySet;
-                for (size_t v = 0; v < c_nrElementsToLookUp; ++v)
-                    mySet.emplace(v);
+		template<typename TMutex, template<typename> typename TReadLock, bool readOnly>
+		void runStdUnorderedMapMutex(const std::string& title)
+		{
+			std::unordered_set<size_t> mySet;
+			for (size_t v = 0; v < c_nrElementsToLookUp; ++v)
+				mySet.emplace(v);
 
-                TMutex m;
-                {
-                    Timer timer{ title };
-                    std::vector<std::future<void>> futures{std::thread::hardware_concurrency()};
+			TMutex m;
+			{
+				Timer timer{ title };
+				std::vector<std::future<void>> futures{ std::thread::hardware_concurrency() };
 
-                    auto f = [&m, &mySet, this]()
-                    {
-                        for (size_t round = 0; round < c_nrRounds; ++round)
-                            for (auto v = 0; v < c_nrElementsToLookUp; ++v)
-                            {
-                                if constexpr (!readOnly)
-                                {
-                                    TReadLock<TMutex> l {m};
-                                    if (mySet.find(v) == mySet.end())
-                                        throw std::exception("Wrong");
-                                }
-                                else
-                                {
-                                    if (mySet.find(v) == mySet.end())
-                                        throw std::exception("Wrong");
-                                }
-                            }
-                    };
+				auto f = [&m, &mySet, this]()
+				{
+					for (size_t round = 0; round < c_nrRounds; ++round)
+						for (auto v = 0; v < c_nrElementsToLookUp; ++v)
+						{
+							if constexpr (!readOnly)
+							{
+								TReadLock<TMutex> l{ m };
+								if (mySet.find(v) == mySet.end())
+									throw std::exception("Wrong");
+							}
+							else
+							{
+								if (mySet.find(v) == mySet.end())
+									throw std::exception("Wrong");
+							}
+						}
+				};
 
-                    for (auto& myFuture : futures)
-                        myFuture = std::async(std::launch::async, f);
+				for (auto& myFuture : futures)
+					myFuture = std::async(std::launch::async, f);
 
+				// some seldom writing operations
+				if (!readOnly)
+					for (auto i = 0; i < c_nrElementsToLookUp; ++i)
+					{
+						if (i % 1024 != 0)
+							continue;
+						std::lock_guard<TMutex> l{ m };
+						auto v = i + c_nrElementsToLookUp;
+						mySet.emplace(v);
+					}
+				for (auto& myFuture : futures)
+					myFuture.get();
+			}
+		}
 
-                    //some seldom writing operations
-                    if (!readOnly)
-                        for (auto i = 0; i < c_nrElementsToLookUp; ++i)
-                        {
-                            if (i % 1024 != 0)
-                                continue;
-                            std::lock_guard<TMutex> l {m};
-                            auto v = i + c_nrElementsToLookUp;
-                            mySet.emplace(v);
-                        }
-                    for (auto& myFuture : futures)
-                        myFuture.get();
-                }
-            }
+		void runRcuHashMap()
+		{
+			RTable rTable;
+			rTableInit(rTable);
+			// user data to be tracked by the hash table
+			struct MyElement
+			{
+				size_t value;
+				RNode entry;
+			};
 
-            void runRcuHashMap()
-            {
-                RTable rTable;
-                rTableInit(rTable);
-                //user data to be tracked by the hash table
-                struct MyElement
-                {
-                    size_t value;
-                    RNode entry;
-                };
+			// here we use the slow heap allocated elements to mimic the std::unordered_set behavior
+			// to rule out the cache perf influence
+			std::vector<std::unique_ptr<MyElement>> myData{ c_nrElementsToLookUp };
+			for (size_t item = 0; item < myData.size(); ++item)
+			{
+				myData[item] = std::make_unique<MyElement>();
+				myData[item]->value = item;
+				auto hashVal = std::hash<size_t>{}(item);
+				bool inserted = rTableTryInsert(
+						rTable,
+						&myData[item]->entry,
+						hashVal,
+						[](RNode* p1, RNode* p2)
+						{
+							return YJ_CONTAINER_OF(p1, MyElement, entry)->value ==
+										 YJ_CONTAINER_OF(p2, MyElement, entry)->value;
+						});
+			}
 
-                //here we use the slow heap allocated elements to mimic the std::unordered_set behavior to rule out the cache perf influence
-                std::vector<std::unique_ptr<MyElement>> myData {c_nrElementsToLookUp};
-                for (size_t item = 0; item < myData.size(); ++item)
-                {
-                    myData[item] = std::make_unique<MyElement>();
-                    myData[item]->value = item;
-                    auto hashVal = std::hash<size_t>{}(item);
-                    bool inserted = rTableTryInsert(rTable, &myData[item]->entry, hashVal, [](RNode* p1, RNode* p2)
-                        {
-                            return YJ_CONTAINER_OF(p1, MyElement, entry)->value == YJ_CONTAINER_OF(p2, MyElement, entry)->value;
-                        });
-                }
+			{
+				Timer timer{ "rTable: " };
+				std::vector<std::future<void>> futures{ std::thread::hardware_concurrency() };
+				auto f = [&rTable, &myData, this]()
+				{
+					for (size_t round = 0; round < c_nrRounds; ++round)
+						for (auto i = 0; i < myData.size(); ++i)
+						{
+							RTableReadLockGuard l(rTable);
+							auto hashVal = std::hash<size_t>{}(myData[i]->value);
+							RNode* pEntry = rTableFind(
+									rTable,
+									hashVal,
+									[i](const RNode* p) { return YJ_CONTAINER_OF(p, MyElement, entry)->value == i; });
+							if (!pEntry)
+								throw std::exception("Wrong");
+						}
+				};
 
-                {
-                    Timer timer{ "rTable: " };
-                    std::vector<std::future<void>> futures{std::thread::hardware_concurrency()};
-                    auto f = [&rTable, &myData, this]()
-                    {
-                        for (size_t round = 0; round < c_nrRounds; ++round)
-                            for (auto i = 0; i < myData.size(); ++i)
-                            {
+				for (auto& myFuture : futures)
+					myFuture = std::async(std::launch::async, f);
 
-                                RTableReadLockGuard l(rTable);
-                                auto hashVal = std::hash<size_t>{}(myData[i]->value);
-                                RNode* pEntry = rTableFind(rTable, hashVal, [i](const RNode* p)
-                                    {
-                                        return YJ_CONTAINER_OF(p, MyElement, entry)->value == i;
-                                    });
-                                if (!pEntry)
-                                    throw std::exception("Wrong");
-                            }
-                    };
+				// some seldom writing operations
+				std::vector<std::unique_ptr<MyElement>> myDataAdditional{ c_nrElementsToLookUp };
+				for (auto i = 0; i < myData.size(); ++i)
+				{
+					if (i % 1024 != 0)
+						continue;
+					auto v = i + myData.size();
+					myDataAdditional[i] = std::make_unique<MyElement>();
+					myDataAdditional[i]->value = v;
+					auto hash = std::hash<size_t>{}(myDataAdditional[i]->value);
 
-                    for (auto& myFuture : futures)
-                        myFuture = std::async(std::launch::async, f);
+					bool inserted = rTableTryInsert(
+							rTable,
+							&myDataAdditional[i]->entry,
+							hash,
+							[](const RNode* p0, const RNode* p1)
+							{
+								return YJ_CONTAINER_OF(p0, MyElement, entry)->value ==
+											 YJ_CONTAINER_OF(p0, MyElement, entry)->value;
+							});
+				}
 
-                    //some seldom writing operations
-                    std::vector<std::unique_ptr<MyElement>> myDataAdditional {c_nrElementsToLookUp};
-                    for (auto i = 0; i < myData.size(); ++i)
-                    {
-                        if (i % 1024 != 0)
-                            continue;
-                        auto v = i + myData.size();
-                        myDataAdditional[i] = std::make_unique<MyElement>();
-                        myDataAdditional[i]->value = v;
-                        auto hash = std::hash<size_t>{}(myDataAdditional[i]->value);
+				for (auto& myFuture : futures)
+					myFuture.get();
+			}
+		};
 
-                        bool inserted = rTableTryInsert(rTable, &myDataAdditional[i]->entry, hash,
-                            [](const RNode* p0, const RNode* p1)
-                            {return YJ_CONTAINER_OF(p0, MyElement, entry)->value == YJ_CONTAINER_OF(p0, MyElement, entry)->value;  }
-                        );
-                    }
+		void run()
+		{
+			runStdUnorderedMapMutex<std::shared_mutex, std::shared_lock, true>("UnorderedMap read only");
+			runStdUnorderedMapMutex<std::shared_mutex, std::shared_lock, false>(
+					"UnorderedMap with std::shared_mutex");
+			runStdUnorderedMapMutex<std::mutex, std::lock_guard, false>("UnorderedMap with std::mutex");
+			runRcuHashMap();
+		}
+	};
 
-                    for (auto& myFuture : futures)
-                        myFuture.get();
-                }
-            };
+	struct RCUTableNormalUsageStress
+	{
+	 public:
+		size_t myHash(size_t v)
+		{
+			return std::hash<size_t>{}(v);
+		}
+		void run()
+		{
+			RTable rTable;
+			RTableConfig conf{};
+			conf.nrRcuBucketsForUnregisteredThreads = 64 * std::thread::hardware_concurrency();
+			rTableInitDetailed(rTable, conf);
 
-            void run()
-            {
-                runStdUnorderedMapMutex<std::shared_mutex, std::shared_lock, true>("UnorderedMap read only");
-                runStdUnorderedMapMutex<std::shared_mutex, std::shared_lock, false>("UnorderedMap with std::shared_mutex");
-                runStdUnorderedMapMutex<std::mutex, std::lock_guard, false>("UnorderedMap with std::mutex");
-                runRcuHashMap();
-            }
-        };
+			struct Val
+			{
+				size_t v;
+				RNode entry;
+				bool valid = false;
+			};
 
-        struct RCUTableNormalUsageStress
-        {
-        public:
-            size_t myHash(size_t v)
-            {
-                return std::hash<size_t>{}(v);
-            }
-            void run()
-            {
-                RTable rTable;
-                RTableConfig conf{};
-                conf.nrRcuBucketsForUnregisteredThreads = 64 * std::thread::hardware_concurrency();
-                rTableInitDetailed(rTable, conf);
+			size_t sizeTotal = 888888;
+			size_t sizePersist = 888;
 
-                struct Val
-                {
-                    size_t v;
-                    RNode entry;
-                    bool valid = false;
-                };
+			std::vector<Val> arr = std::vector<Val>{ sizeTotal };
 
-                size_t sizeTotal = 888888;
-                size_t sizePersist = 888;
+			for (size_t i = 0; i < sizePersist; ++i)
+			{
+				arr[i].v = i;
+				arr[i].valid = true;
+				auto hash = myHash(i);
 
-                std::vector<Val> arr = std::vector<Val>{ sizeTotal };
+				bool inserted = rTableTryInsert(
+						rTable,
+						&arr[i].entry,
+						hash,
+						[](RNode* p1, RNode* p2)
+						{ return YJ_CONTAINER_OF(p1, Val, entry)->v == YJ_CONTAINER_OF(p2, Val, entry)->v; });
+				if (!inserted)
+					throw std::exception("Broken");
 
-                for (size_t i = 0; i < sizePersist; ++i)
-                {
-                    arr[i].v = i;
-                    arr[i].valid = true;
-                    auto hash = myHash(i);
+				// rTableInsert(rTable, &arr[i].entry);
+				// printRCUTable(rTable);
+			}
 
-                    bool inserted = rTableTryInsert(rTable, &arr[i].entry, hash,
-                        [](RNode* p1, RNode* p2)
-                        {
-                            return YJ_CONTAINER_OF(p1, Val, entry)->v == YJ_CONTAINER_OF(p2, Val, entry)->v;
-                        }
-                    );
-                    if (!inserted)
-                        throw std::exception("Broken");
+			std::atomic<bool> finished = false;
 
-                    //rTableInsert(rTable, &arr[i].entry);
-                    //printRCUTable(rTable);
-                }
+			auto f = [&]()
+			{
+				while (!finished.load(std::memory_order_relaxed))
+				{
+					for (size_t i = 0; i < sizePersist; ++i)
+					{
+						size_t hashVal = myHash(i);
+						auto epoch = rTableReadLock(rTable);
+						bool found = rTableFind(
+								rTable, hashVal, [&](RNode* p) { return YJ_CONTAINER_OF(p, Val, entry)->v == i; });
+						if (found && !arr[i].valid)
+							throw std::exception("ElementNotValid in reader critical session.");
+						rTableReadUnlock(rTable, epoch);
+						if (i < sizePersist && !found)
+							throw std::exception("Broken");
+					}
+				}
+			};
 
-                std::atomic<bool> finished = false;
+			std::future<void> futures[7];
+			for (auto& future : futures)
+				future = std::async(std::launch::async, f);
 
-                auto f = [&]()
-                {
-                    while (!finished.load(std::memory_order_relaxed))
-                    {
-                        for (size_t i = 0; i < sizePersist; ++i)
-                        {
-                            size_t hashVal = myHash(i);
-                            auto epoch = rTableReadLock(rTable);
-                            bool found = rTableFind(rTable, hashVal, [&](RNode* p)
-                                {
-                                    return YJ_CONTAINER_OF(p, Val, entry)->v == i;
-                                }
-                            );
-                            if (found && !arr[i].valid)
-                                throw std::exception("ElementNotValid in reader critical session.");
-                            rTableReadUnlock(rTable, epoch);
-                            if (i < sizePersist && !found)
-                                throw std::exception("Broken");
-                        }
-                    }
-                };
+			rTableSynchronize(rTable);
+			for (auto i = sizePersist; i < sizeTotal; ++i)
+			{
+				arr[i].v = i;
+				arr[i].valid = true;
+				auto hash = myHash(i);
+				bool inserted = rTableTryInsert(
+						rTable,
+						&arr[i].entry,
+						hash,
+						[](RNode* p1, RNode* p2)
+						{ return YJ_CONTAINER_OF(p1, Val, entry)->v == YJ_CONTAINER_OF(p2, Val, entry)->v; });
+				if (!inserted)
+					throw std::exception("Broken");
+			}
 
-                std::future<void> futures[7];
-                for (auto& future : futures)
-                    future = std::async(std::launch::async, f);
+			// periodically remove and insert
+			for (int j = 0; j < 3000; ++j)
+			{
+				std::cout << j << " round of erasing and inserting." << std::endl;
+				for (auto i = sizePersist; i < sizeTotal; ++i)
+				{
+					auto hash = myHash(i);
 
+					RNode* pEntry = rTableTryDetachAndSynchronize(
+							rTable, hash, [i](RNode* p) { return YJ_CONTAINER_OF(p, Val, entry)->v == i; });
 
-                rTableSynchronize(rTable);
-                for (auto i = sizePersist; i < sizeTotal; ++i)
-                {
-                    arr[i].v = i;
-                    arr[i].valid = true;
-                    auto hash = myHash(i);
-                    bool inserted = rTableTryInsert(rTable, &arr[i].entry, hash,
-                        [](RNode* p1, RNode* p2)
-                        {
-                            return YJ_CONTAINER_OF(p1, Val, entry)->v == YJ_CONTAINER_OF(p2, Val, entry)->v;
-                        }
-                    );
-                    if (!inserted)
-                        throw std::exception("Broken");
-                }
+					YJ_CONTAINER_OF(pEntry, Val, entry)->valid = false;
+					if (!pEntry)
+						throw std::exception("Broken");
+				}
 
-                //periodically remove and insert
-                for (int j = 0; j < 3000; ++j)
-                {
-                    std::cout << j << " round of erasing and inserting." << std::endl;
-                    for (auto i = sizePersist; i < sizeTotal; ++i)
-                    {
-                        auto hash = myHash(i);
+				for (auto i = sizePersist; i < sizeTotal; ++i)
+				{
+					arr[i].v = i;
+					arr[i].valid = true;
+					auto hash = myHash(i);
 
-                        RNode* pEntry = rTableTryDetachAndSynchronize(rTable, hash, [i](RNode* p)
-                            {return YJ_CONTAINER_OF(p, Val, entry)->v == i; }
-                        );
+					bool inserted = rTableTryInsert(
+							rTable,
+							&arr[i].entry,
+							hash,
+							[](RNode* p1, RNode* p2)
+							{ return YJ_CONTAINER_OF(p1, Val, entry)->v == YJ_CONTAINER_OF(p2, Val, entry)->v; });
+					if (!inserted)
+						throw std::exception("Broken");
+				}
+			}
 
-                        YJ_CONTAINER_OF(pEntry, Val, entry)->valid = false;
-                        if (!pEntry)
-                            throw std::exception("Broken");
-                    }
+			finished.store(true, std::memory_order_relaxed);
 
-                    for (auto i = sizePersist; i < sizeTotal; ++i)
-                    {
-                        arr[i].v = i;
-                        arr[i].valid = true;
-                        auto hash = myHash(i);
+			for (auto& future : futures)
+				future.get();
 
-                        bool inserted = rTableTryInsert(rTable, &arr[i].entry, hash,
-                            [](RNode* p1, RNode* p2)
-                            {
-                                return YJ_CONTAINER_OF(p1, Val, entry)->v == YJ_CONTAINER_OF(p2, Val, entry)->v;
-                            }
-                        );
-                        if (!inserted)
-                            throw std::exception("Broken");
-                    }
-                }
+			for (auto i = 0; i < sizePersist; ++i)
+			{
+				size_t hashVal = myHash(i);
+				bool found = rTableFind(
+						rTable, hashVal, [&](RNode* p) { return YJ_CONTAINER_OF(p, Val, entry)->v == i; });
+				if (!found)
+					throw std::exception("Broken");
+			}
+		}
+	};
 
-                finished.store(true, std::memory_order_relaxed);
+	struct RCUTableManualStressExpandShrink
+	{
+	 public:
+		struct Val
+		{
+			size_t v;
+			RNode entry;
+		};
+		size_t sizeTotal = 8888;
+		size_t myHash(size_t v, size_t seed)
+		{
+			return std::hash<size_t>{}(v + seed);
+		}
 
-                for (auto& future : futures)
-                    future.get();
+		void run()
+		{
+			RTableConfig conf{};
+			conf.nrBuckets = 4;
+			conf.nrRcuBucketsForUnregisteredThreads = 64 * std::thread::hardware_concurrency();
+			for (int j = 1; j < 100; ++j)
+			{
+				RTable rTable;
+				rTableInitDetailed(rTable, conf);
+				std::vector<Val> arr = std::vector<Val>{ sizeTotal };
+				for (size_t i = 0; i < sizeTotal; ++i)
+				{
+					arr[i].v = i;
+					auto hash = myHash(i, j);
+					bool inserted = rTableTryInsertNoExpand(
+							rTable,
+							&arr[i].entry,
+							hash,
+							[](RNode* p1, RNode* p2)
+							{ return YJ_CONTAINER_OF(p1, Val, entry)->v == YJ_CONTAINER_OF(p2, Val, entry)->v; });
+					if (!inserted)
+						throw std::exception("Broken");
+				}
 
+				std::atomic<bool> finished = false;
 
-                for (auto i = 0; i < sizePersist; ++i)
-                {
-                    size_t hashVal = myHash(i);
-                    bool found = rTableFind(rTable, hashVal, [&](RNode* p)
-                        {
-                            return YJ_CONTAINER_OF(p, Val, entry)->v == i;
-                        }
-                    );
-                    if (!found)
-                        throw std::exception("Broken");
-                }
+				auto f = [&]()
+				{
+					while (!finished.load(std::memory_order_relaxed))
+					{
+						for (size_t i = 0; i < sizeTotal; ++i)
+						{
+							size_t hashVal = myHash(i, j);
+							auto epoch = rTableReadLock(rTable);
+							bool found = rTableFind(
+									rTable,
+									hashVal,
+									[&](RNode* p) { return YJ_CONTAINER_OF(p, Val, entry)->v == i; });
+							if (!found)
+								throw std::exception("Broken");
+							rTableReadUnlock(rTable, epoch);
+						}
+					}
+				};
 
-            }
-        };
+				std::future<void> futures[7];
+				for (auto& future : futures)
+					future = std::async(std::launch::async, f);
 
+				// periodically remove and insert
+				for (int j = 0; j < 30; ++j)
+				{
+					// std::cout << j << " round of erasing and inserting." << std::endl;
+					rTableExpandBuckets2x(rTable);
+					rTableExpandBuckets2x(rTable);
+					rTableExpandBuckets2x(rTable);
 
-        struct RCUTableManualStressExpandShrink
-        {
-        public:
-            struct Val
-            {
-                size_t v;
-                RNode entry;
-            };
-            size_t sizeTotal = 8888;
-            size_t myHash(size_t v, size_t seed)
-            {
-                return std::hash<size_t>{}(v + seed);
-            }
+					rTableShrinkBuckets2x(rTable);
+					rTableShrinkBuckets2x(rTable);
+					rTableShrinkBuckets2x(rTable);
+				}
 
-            void run()
-            {
-                RTableConfig conf{};
-                conf.nrBuckets = 4;
-                conf.nrRcuBucketsForUnregisteredThreads = 64 * std::thread::hardware_concurrency();
-                for (int j = 1; j < 100; ++j)
-                {
-                    RTable rTable;
-                    rTableInitDetailed(rTable, conf);
-                    std::vector<Val> arr = std::vector<Val>{ sizeTotal };
-                    for (size_t i = 0; i < sizeTotal; ++i)
-                    {
-                        arr[i].v = i;
-                        auto hash = myHash(i, j);
-                        bool inserted = rTableTryInsertNoExpand(rTable, &arr[i].entry, hash,
-                            [](RNode* p1, RNode* p2)
-                            {
-                                return YJ_CONTAINER_OF(p1, Val, entry)->v == YJ_CONTAINER_OF(p2, Val, entry)->v;
-                            }
-                        );
-                        if (!inserted)
-                            throw std::exception("Broken");
-                    }
+				finished.store(true, std::memory_order_relaxed);
 
-                    std::atomic<bool> finished = false;
+				for (auto& future : futures)
+					future.get();
+			}
+		}
+	};
 
-                    auto f = [&]()
-                    {
-                        while (!finished.load(std::memory_order_relaxed))
-                        {
-                            for (size_t i = 0; i < sizeTotal; ++i)
-                            {
-                                size_t hashVal = myHash(i, j);
-                                auto epoch = rTableReadLock(rTable);
-                                bool found = rTableFind(rTable, hashVal, [&](RNode* p)
-                                    {
-                                        return YJ_CONTAINER_OF(p, Val, entry)->v == i;
-                                    }
-                                );
-                                if (!found)
-                                    throw std::exception("Broken");
-                                rTableReadUnlock(rTable, epoch);
-                            }
-                        }
-                    };
+	void RCUTableTestSingleThreadTest()
+	{
+		RTable tbl;
+		rTableInit(tbl);
 
-                    std::future<void> futures[7];
-                    for (auto& future : futures)
-                        future = std::async(std::launch::async, f);
+		struct Element
+		{
+			size_t v;
+			RNode entry;
+			static Element* fromNode(RNode* pEntry)
+			{
+				return YJ_CONTAINER_OF(pEntry, Element, entry);
+			}
+		};
+		std::vector<Element> values{ 1000 };
+		for (size_t i = 0; i < values.size(); ++i)
+			values[i].v = i;
 
-                    //periodically remove and insert
-                    for (int j = 0; j < 30; ++j)
-                    {
-                        //std::cout << j << " round of erasing and inserting." << std::endl;
-                        rTableExpandBuckets2x(rTable);
-                        rTableExpandBuckets2x(rTable);
-                        rTableExpandBuckets2x(rTable);
+		// when there is only one thread, read lock is not needed
+		for (size_t i = 0; i < values.size(); ++i)
+		{
+			bool inserted = rTableTryInsert(
+					tbl,
+					&values[i].entry,
+					std::hash<size_t>{}(i),
+					[](RNode* p0, RNode* p1)
+					{ return Element::fromNode(p0)->v == Element::fromNode(p1)->v; });
+			if (!inserted)
+				throw std::exception("Broken");
+			bool insertedSecondTime = rTableTryInsert(
+					tbl,
+					&values[i].entry,
+					std::hash<size_t>{}(i),
+					[](RNode* p0, RNode* p1)
+					{ return Element::fromNode(p0)->v == Element::fromNode(p1)->v; });
+			if (insertedSecondTime)
+				throw std::exception("Broken");
+		}
 
-                        rTableShrinkBuckets2x(rTable);
-                        rTableShrinkBuckets2x(rTable);
-                        rTableShrinkBuckets2x(rTable);
-                    }
+		bool foundNotInElement = rTableFind(
+				tbl,
+				std::hash<size_t>{}(values.size()),
+				[val = values.size()](RNode* p) { return Element::fromNode(p)->v == val; });
+		if (foundNotInElement)
+			throw std::exception("Broken");
 
-                    finished.store(true, std::memory_order_relaxed);
+		for (size_t i = 0; i < values.size(); ++i)
+		{
+			RNode* detached = rTableTryDetachAutoShrink(
+					tbl, std::hash<size_t>{}(i), [i](RNode* p) { return Element::fromNode(p)->v == i; });
+			if (!detached)
+				throw std::exception("Broken");
+		}
 
-                    for (auto& future : futures)
-                        future.get();
+		for (size_t i = 0; i < values.size(); ++i)
+		{
+			bool foundNotInElement = rTableFind(
+					tbl,
+					std::hash<size_t>{}(values.size()),
+					[val = values.size()](RNode* p) { return Element::fromNode(p)->v == val; });
+			if (foundNotInElement)
+				throw std::exception("Broken");
+		}
+	}
+}	 // namespace
 
-                }
-            }
-        };
+void rTableTests()
+{
+	RCUTableManualStressExpandShrink testManualShrinkExpand;
+	testManualShrinkExpand.run();
 
-        void RCUTableTestSingleThreadTest()
-        {
-            RTable tbl;
-            rTableInit(tbl);
+	RCUTableTestSingleThreadTest();
 
-            struct Element
-            {
-                size_t v;
-                RNode entry;
-                static Element* fromNode(RNode* pEntry)
-                {
-                    return YJ_CONTAINER_OF(pEntry, Element, entry);
-                }
-            };
-            std::vector<Element> values{1000};
-            for (size_t i = 0; i < values.size(); ++i)
-                values[i].v = i;
+	PerfComparisonWithStdUnorderedSet comp;
+	comp.run();
 
-            //when there is only one thread, read lock is not needed
-            for (size_t i = 0; i < values.size(); ++i)
-            {
-                bool inserted = rTableTryInsert(tbl, &values[i].entry, std::hash<size_t>{}(i),
-                    [](RNode* p0, RNode* p1) {
-                        return Element::fromNode(p0)->v == Element::fromNode(p1)->v;
-                    }
-                );
-                if (!inserted)
-                    throw std::exception("Broken");
-                bool insertedSecondTime = rTableTryInsert(tbl, &values[i].entry, std::hash<size_t>{}(i),
-                    [](RNode* p0, RNode* p1) {
-                        return Element::fromNode(p0)->v == Element::fromNode(p1)->v;
-                    }
-                );
-                if (insertedSecondTime)
-                    throw std::exception("Broken");
-            }
-
-            bool foundNotInElement = rTableFind(tbl, std::hash<size_t>{}(values.size()),
-                [val = values.size()](RNode* p) { return Element::fromNode(p)->v == val; });
-            if (foundNotInElement)
-                throw std::exception("Broken");
-
-            for (size_t i = 0; i < values.size(); ++i)
-            {
-                RNode* detached = rTableTryDetachAutoShrink(tbl, std::hash<size_t>{}(i),
-                    [i](RNode* p) { return Element::fromNode(p)->v == i; });
-                if (!detached)
-                    throw std::exception("Broken");
-            }
-
-            for (size_t i = 0; i < values.size(); ++i)
-            {
-                bool foundNotInElement = rTableFind(tbl, std::hash<size_t>{}(values.size()),
-                    [val = values.size()](RNode* p) { return Element::fromNode(p)->v == val; });
-                if (foundNotInElement)
-                    throw std::exception("Broken");
-            }
-        }
-    }
-
-
-    void rTableTests()
-    {
-        RCUTableManualStressExpandShrink testManualShrinkExpand;
-        testManualShrinkExpand.run();
-
-        RCUTableTestSingleThreadTest();
-
-        PerfComparisonWithStdUnorderedSet comp;
-        comp.run();
-
-        RCUTableNormalUsageStress testNormalUsageStress;
-        testNormalUsageStress.run();
-    }
+	RCUTableNormalUsageStress testNormalUsageStress;
+	testNormalUsageStress.run();
 }
+}	 // namespace yrcu

--- a/Relativistic_Hash_Table/TestsAndExamples/RCUTests.cpp
+++ b/Relativistic_Hash_Table/TestsAndExamples/RCUTests.cpp
@@ -1,323 +1,332 @@
-#include <iostream>
-#include <future>
 #include <cstdlib>
+#include <future>
+#include <iostream>
+#include <memory>
 #include <random>
 #include <shared_mutex>
-#include <memory>
-#include "../LibSource/include/RCUTypes.h"
-#include "../LibSource/include/RCUApi.h"
 
+#include "../LibSource/include/RCUApi.h"
+#include "../LibSource/include/RCUTypes.h"
 
 namespace yrcu
 {
-    namespace
-    {
-        struct RCUBenchmark
-        {
-        private:
-            std::random_device rd;  // a seed source for the random number engine
-            std::mt19937 gen{rd()}; // mersenne_twister_engine seeded with rd()
-            std::uniform_int_distribution<int64_t> distrib{1, 100000000ll};
-            std::shared_mutex sm;
-            std::mutex m;
-            std::atomic<int64_t*> pCurrent;
-            std::atomic<std::shared_ptr<int64_t>> spCurrent;
+namespace
+{
+	struct RCUBenchmark
+	{
+	 private:
+		std::random_device rd;		 // a seed source for the random number engine
+		std::mt19937 gen{ rd() };	 // mersenne_twister_engine seeded with rd()
+		std::uniform_int_distribution<int64_t> distrib{ 1, 100000000ll };
+		std::shared_mutex sm;
+		std::mutex m;
+		std::atomic<int64_t*> pCurrent;
+		std::atomic<std::shared_ptr<int64_t>> spCurrent;
 
-            RCUZone zone;
+		RCUZone zone;
 
-            static constexpr int c_nrLoops = (2ll << 21);
-            static constexpr int c_nrThreads = 8;
-            static constexpr int c_writeInterval = 10000;
+		static constexpr int c_nrLoops = (2ll << 21);
+		static constexpr int c_nrThreads = 8;
+		static constexpr int c_writeInterval = 10000;
 
-            void func(int64_t v)
-            {
-                if (v < 0)
-                    throw std::exception("broken");
-                int64_t res = 1;
-                for (int i = 0; i < 25; ++i)
-                    res *= v + i;
-                if (res % 10000000000 == 0)
-                    std::cout << v << "\n";
-            }
+		void func(int64_t v)
+		{
+			if (v < 0)
+				throw std::exception("broken");
+			int64_t res = 1;
+			for (int i = 0; i < 25; ++i)
+				res *= v + i;
+			if (res % 10000000000 == 0)
+				std::cout << v << "\n";
+		}
 
+		void fReadOnly()
+		{
+			std::future<void> futureModify = std::async(
+					std::launch::async,
+					[&]()
+					{
+						for (int64_t k = 0; k < c_nrLoops; ++k)
+						{
+							if (k % c_writeInterval == 0)
+							{
+								auto* p = new int64_t(distrib(gen));
+								if (*p % 10000000000 == 0)
+									std::cout << "oo\n";
+							}
+						}
+					});
 
-            void fReadOnly()
-            {
-                std::future<void> futureModify = std::async(std::launch::async, [&]()
-                    {
-                        for (int64_t k = 0; k < c_nrLoops; ++k)
-                        {
-                            if (k % c_writeInterval == 0)
-                            {
-                                auto* p = new int64_t(distrib(gen));
-                                if (*p % 10000000000 == 0)
-                                    std::cout << "oo\n";
-                            }
-                        }
+			std::future<void> futures[c_nrThreads];
+			for (int i = 0; i < c_nrThreads; ++i)
+			{
+				futures[i] = std::async(
+						std::launch::async,
+						[&]()
+						{
+							for (int64_t k = 0; k < c_nrLoops; ++k)
+								func(*(pCurrent.load(std::memory_order_relaxed)));
+						});
+			}
+			for (auto& f : futures)
+				f.get();
+			futureModify.get();
+		}
 
-                    });
+		void fSharedMutex()
+		{
+			std::future<void> futureModify = std::async(
+					std::launch::async,
+					[&]()
+					{
+						for (int64_t k = 0; k < c_nrLoops; ++k)
+						{
+							if (k % c_writeInterval == 0)
+							{
+								std::lock_guard<std::shared_mutex> l{ sm };
+								auto pOld = pCurrent.load(std::memory_order_relaxed);
+								pCurrent.store(new int64_t(distrib(gen)), std::memory_order_relaxed);
+								delete pOld;
+							}
+						}
+					});
+			std::future<void> futures[c_nrThreads];
+			for (int i = 0; i < c_nrThreads; ++i)
+			{
+				futures[i] = std::async(
+						std::launch::async,
+						[&]()
+						{
+							for (int64_t k = 0; k < c_nrLoops; ++k)
+							{
+								std::shared_lock<std::shared_mutex> l{ sm };
+								func(*(pCurrent.load(std::memory_order_relaxed)));
+							}
+						});
+			}
+			for (auto& f : futures)
+				f.get();
+			futureModify.get();
+		}
 
-                std::future<void> futures[c_nrThreads];
-                for (int i = 0; i < c_nrThreads; ++i)
-                {
-                    futures[i] = std::async(std::launch::async,
-                        [&]()
-                        {
-                            for (int64_t k = 0; k < c_nrLoops; ++k)
-                                func(*(pCurrent.load(std::memory_order_relaxed)));
-                        }
-                    );
-                }
-                for (auto& f : futures)
-                    f.get();
-                futureModify.get();
-            }
+		void fMutex()
+		{
+			std::future<void> futureModify = std::async(
+					std::launch::async,
+					[&]()
+					{
+						for (int64_t k = 0; k < c_nrLoops; ++k)
+						{
+							if (k % c_writeInterval == 0)
+							{
+								std::lock_guard<std::mutex> l{ m };
+								auto pOld = pCurrent.load(std::memory_order_relaxed);
+								pCurrent = new int64_t(distrib(gen));
+								delete pOld;
+							}
+						}
+					});
+			std::future<void> futures[c_nrThreads];
+			for (int i = 0; i < c_nrThreads; ++i)
+			{
+				futures[i] = std::async(
+						std::launch::async,
+						[&]()
+						{
+							for (int64_t k = 0; k < c_nrLoops; ++k)
+							{
+								std::lock_guard<std::mutex> l{ m };
+								func(*(pCurrent.load(std::memory_order_relaxed)));
+							}
+						});
+			}
+			for (auto& f : futures)
+				f.get();
+			futureModify.get();
+		}
 
-            void fSharedMutex()
-            {
-                std::future<void> futureModify = std::async(std::launch::async, [&]()
-                    {
-                        for (int64_t k = 0; k < c_nrLoops; ++k)
-                        {
-                            if (k % c_writeInterval == 0)
-                            {
-                                std::lock_guard<std::shared_mutex> l {sm};
-                                auto pOld = pCurrent.load(std::memory_order_relaxed);
-                                pCurrent.store(new int64_t(distrib(gen)), std::memory_order_relaxed);
-                                delete pOld;
-                            }
-                        }
+		void fRCU()
+		{
+			std::future<void> futureModify = std::async(
+					std::launch::async,
+					[&]()
+					{
+						for (int64_t k = 0; k < c_nrLoops; ++k)
+						{
+							if (k % c_writeInterval == 0)
+							{
+								auto pOld = pCurrent.load(std::memory_order_acquire);
+								pCurrent.store(new int64_t(distrib(gen)), std::memory_order_release);
+								rcuSynchronize(zone);
+								delete pOld;
+							}
+						}
+					});
+			std::future<void> futures[c_nrThreads];
+			for (int i = 0; i < c_nrThreads; ++i)
+			{
+				futures[i] = std::async(
+						std::launch::async,
+						[&]()
+						{
+							for (int64_t k = 0; k < c_nrLoops; ++k)
+							{
+								auto epoch = rcuReadLock(zone);
+								func(*(pCurrent.load(std::memory_order_acquire)));
+								rcuReadUnlock(zone, epoch);
+							}
+						});
+			}
+			for (auto& f : futures)
+				f.get();
+			futureModify.get();
+		}
 
-                    });
-                std::future<void> futures[c_nrThreads];
-                for (int i = 0; i < c_nrThreads; ++i)
-                {
-                    futures[i] = std::async(std::launch::async,
-                        [&]()
-                        {
-                            for (int64_t k = 0; k < c_nrLoops; ++k)
-                            {
-                                std::shared_lock<std::shared_mutex> l {sm};
-                                func(*(pCurrent.load(std::memory_order_relaxed)));
-                            }
-                        }
-                    );
-                }
-                for (auto& f : futures)
-                    f.get();
-                futureModify.get();
-            }
+		void fRCURegister()
+		{
+			std::future<void> futureModify = std::async(
+					std::launch::async,
+					[&]()
+					{
+						for (int64_t k = 0; k < c_nrLoops; ++k)
+						{
+							if (k % c_writeInterval == 0)
+							{
+								auto pOld = pCurrent.load(std::memory_order_acquire);
+								pCurrent.store(new int64_t(distrib(gen)), std::memory_order_release);
+								rcuSynchronize(zone);
+								delete pOld;
+							}
+						}
+					});
+			std::atomic<int> latch = 0;
+			std::future<void> futures[c_nrThreads];
+			for (int i = 0; i < c_nrThreads; ++i)
+			{
+				futures[i] = std::async(
+						std::launch::async,
+						[&]()
+						{
+							rcuRegisterReaderThread();
+							latch++;
+							while (latch < 8)
+								continue;
+							for (int64_t k = 0; k < c_nrLoops; ++k)
+							{
+								auto epoch = rcuReadLock(zone);
+								func(*(pCurrent.load(std::memory_order_acquire)));
+								rcuReadUnlock(zone, epoch);
+							}
+						});
+			}
+			for (auto& f : futures)
+				f.get();
+			futureModify.get();
+		}
 
-            void fMutex()
-            {
-                std::future<void> futureModify = std::async(std::launch::async, [&]()
-                    {
-                        for (int64_t k = 0; k < c_nrLoops; ++k)
-                        {
-                            if (k % c_writeInterval == 0)
-                            {
-                                std::lock_guard<std::mutex> l {m};
-                                auto pOld = pCurrent.load(std::memory_order_relaxed);
-                                pCurrent = new int64_t(distrib(gen));
-                                delete pOld;
-                            }
-                        }
+		void fAtomicSharedPtr()
+		{
+			std::future<void> futureModify = std::async(
+					std::launch::async,
+					[&]()
+					{
+						for (int64_t k = 0; k < c_nrLoops; ++k)
+							if (k % c_writeInterval == 0)
+								spCurrent = std::make_shared<int64_t>(distrib(gen));
+					});
+			std::future<void> futures[c_nrThreads];
+			for (int i = 0; i < c_nrThreads; ++i)
+			{
+				futures[i] = std::async(
+						std::launch::async,
+						[&]()
+						{
+							for (int64_t k = 0; k < c_nrLoops; ++k)
+								func(*(spCurrent.load(std::memory_order_relaxed)));
+						});
+			}
+			for (auto& f : futures)
+				f.get();
+			futureModify.get();
+		}
 
-                    });
-                std::future<void> futures[c_nrThreads];
-                for (int i = 0; i < c_nrThreads; ++i)
-                {
-                    futures[i] = std::async(std::launch::async,
-                        [&]()
-                        {
-                            for (int64_t k = 0; k < c_nrLoops; ++k)
-                            {
-                                std::lock_guard<std::mutex> l {m};
-                                func(*(pCurrent.load(std::memory_order_relaxed)));
-                            }
-                        }
-                    );
-                }
-                for (auto& f : futures)
-                    f.get();
-                futureModify.get();
-            }
+	 public:
+		void run()
+		{
+			std::cout << "hardware concurrency: " << std::thread::hardware_concurrency() << std::endl;
+			std::cout << "Nr threads: " << c_nrThreads << std::endl;
+			pCurrent = new int64_t(distrib(gen));
+			rcuInitZone(zone);
 
-            void fRCU()
-            {
-                std::future<void> futureModify = std::async(std::launch::async, [&]()
-                    {
-                        for (int64_t k = 0; k < c_nrLoops; ++k)
-                        {
-                            if (k % c_writeInterval == 0)
-                            {
-                                auto pOld = pCurrent.load(std::memory_order_acquire);
-                                pCurrent.store(new int64_t(distrib(gen)), std::memory_order_release);
-                                rcuSynchronize(zone);
-                                delete pOld;
-                            }
-                        }
+			if (true)
+			{
+				auto timeStart = std::chrono::system_clock::now();
+				fRCURegister();
+				auto timeFinish = std::chrono::system_clock::now();
+				auto diff = timeFinish - timeStart;
+				std::cout << "RCU_REGISTER: "
+									<< std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << "_ms\n";
+			}
 
-                    });
-                std::future<void> futures[c_nrThreads];
-                for (int i = 0; i < c_nrThreads; ++i)
-                {
-                    futures[i] = std::async(std::launch::async,
-                        [&]()
-                        {
-                            for (int64_t k = 0; k < c_nrLoops; ++k)
-                            {
-                                auto epoch = rcuReadLock(zone);
-                                func(*(pCurrent.load(std::memory_order_acquire)));
-                                rcuReadUnlock(zone, epoch);
-                            }
-                        }
-                    );
-                }
-                for (auto& f : futures)
-                    f.get();
-                futureModify.get();
-            }
+			if (true)
+			{
+				auto timeStart = std::chrono::system_clock::now();
+				fRCU();
+				auto timeFinish = std::chrono::system_clock::now();
+				auto diff = timeFinish - timeStart;
+				std::cout << "FRCU__RCU___: "
+									<< std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << "_ms\n";
+			}
 
-            void fRCURegister()
-            {
-                std::future<void> futureModify = std::async(std::launch::async, [&]()
-                    {
-                        for (int64_t k = 0; k < c_nrLoops; ++k)
-                        {
-                            if (k % c_writeInterval == 0)
-                            {
-                                auto pOld = pCurrent.load(std::memory_order_acquire);
-                                pCurrent.store(new int64_t(distrib(gen)), std::memory_order_release);
-                                rcuSynchronize(zone);
-                                delete pOld;
-                            }
-                        }
+			if (true)
+			{
+				auto timeStart = std::chrono::system_clock::now();
+				fReadOnly();
+				auto timeFinish = std::chrono::system_clock::now();
+				auto diff = timeFinish - timeStart;
+				std::cout << "FReadOnly___: "
+									<< std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << "_ms\n";
+			}
 
-                    });
-                std::atomic<int> latch = 0;
-                std::future<void> futures[c_nrThreads];
-                for (int i = 0; i < c_nrThreads; ++i)
-                {
-                    futures[i] = std::async(std::launch::async,
-                        [&]()
-                        {
-                            rcuRegisterReaderThread();
-                            latch++;
-                            while (latch < 8)
-                                continue;
-                            for (int64_t k = 0; k < c_nrLoops; ++k)
-                            {
-                                auto epoch = rcuReadLock(zone);
-                                func(*(pCurrent.load(std::memory_order_acquire)));
-                                rcuReadUnlock(zone, epoch);
-                            }
-                        }
-                    );
-                }
-                for (auto& f : futures)
-                    f.get();
-                futureModify.get();
-            }
+			if (true)
+			{
+				auto timeStart = std::chrono::system_clock::now();
+				fAtomicSharedPtr();
+				auto timeFinish = std::chrono::system_clock::now();
+				auto diff = timeFinish - timeStart;
+				std::cout << "FAtomicSRPTR: "
+									<< std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << "_ms\n";
+			}
 
-            void fAtomicSharedPtr()
-            {
-                std::future<void> futureModify = std::async(std::launch::async, [&]()
-                    {
-                        for (int64_t k = 0; k < c_nrLoops; ++k)
-                            if (k % c_writeInterval == 0)
-                                spCurrent = std::make_shared<int64_t>(distrib(gen));
+			if (true)
+			{
+				auto timeStart = std::chrono::system_clock::now();
+				fSharedMutex();
+				auto timeFinish = std::chrono::system_clock::now();
+				auto diff = timeFinish - timeStart;
+				std::cout << "FSharedMutex: "
+									<< std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << "_ms\n";
+			}
 
-                    });
-                std::future<void> futures[c_nrThreads];
-                for (int i = 0; i < c_nrThreads; ++i)
-                {
-                    futures[i] = std::async(std::launch::async,
-                        [&]()
-                        {
-                            for (int64_t k = 0; k < c_nrLoops; ++k)
-                                func(*(spCurrent.load(std::memory_order_relaxed)));
-                        }
-                    );
-                }
-                for (auto& f : futures)
-                    f.get();
-                futureModify.get();
-            }
+			if (true)
+			{
+				auto timeStart = std::chrono::system_clock::now();
+				fMutex();
+				auto timeFinish = std::chrono::system_clock::now();
+				auto diff = timeFinish - timeStart;
+				std::cout << "FMutex______: "
+									<< std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << "_ms\n";
+			}
 
-        public:
-            void run()
-            {
-                std::cout << "hardware concurrency: " << std::thread::hardware_concurrency() << std::endl;
-                std::cout << "Nr threads: " << c_nrThreads << std::endl;
-                pCurrent = new int64_t(distrib(gen));
-                rcuInitZone(zone);
+			rcuReleaseZone(zone);
+		}
+	};
 
-                if (true)
-                {
-                    auto timeStart = std::chrono::system_clock::now();
-                    fRCURegister();
-                    auto timeFinish = std::chrono::system_clock::now();
-                    auto diff = timeFinish - timeStart;
-                    std::cout << "RCU_REGISTER: " << std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << "_ms\n";
-                }
+}	 // namespace
 
-                if (true)
-                {
-                    auto timeStart = std::chrono::system_clock::now();
-                    fRCU();
-                    auto timeFinish = std::chrono::system_clock::now();
-                    auto diff = timeFinish - timeStart;
-                    std::cout << "FRCU__RCU___: " << std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << "_ms\n";
-                }
-
-                if (true)
-                {
-                    auto timeStart = std::chrono::system_clock::now();
-                    fReadOnly();
-                    auto timeFinish = std::chrono::system_clock::now();
-                    auto diff = timeFinish - timeStart;
-                    std::cout << "FReadOnly___: " << std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << "_ms\n";
-                }
-
-                if (true)
-                {
-                    auto timeStart = std::chrono::system_clock::now();
-                    fAtomicSharedPtr();
-                    auto timeFinish = std::chrono::system_clock::now();
-                    auto diff = timeFinish - timeStart;
-                    std::cout << "FAtomicSRPTR: " << std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << "_ms\n";
-                }
-
-
-                if (true)
-                {
-                    auto timeStart = std::chrono::system_clock::now();
-                    fSharedMutex();
-                    auto timeFinish = std::chrono::system_clock::now();
-                    auto diff = timeFinish - timeStart;
-                    std::cout << "FSharedMutex: " << std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << "_ms\n";
-                }
-
-                if (true)
-                {
-                    auto timeStart = std::chrono::system_clock::now();
-                    fMutex();
-                    auto timeFinish = std::chrono::system_clock::now();
-                    auto diff = timeFinish - timeStart;
-                    std::cout << "FMutex______: " << std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << "_ms\n";
-                }
-
-                rcuReleaseZone(zone);
-            }
-        };
-    
-
+void rcuTests()
+{
+	RCUBenchmark test0;
+	test0.run();
 }
-
-    void rcuTests()
-    {
-        RCUBenchmark test0;
-        test0.run();
-    }
-}
+}	 // namespace yrcu

--- a/Relativistic_Hash_Table/TestsAndExamples/TestHelper.h
+++ b/Relativistic_Hash_Table/TestsAndExamples/TestHelper.h
@@ -1,31 +1,32 @@
-#include <iostream>
 #include <chrono>
+#include <iostream>
 #include <string>
 
 namespace yrcu
 {
-    struct Timer
-    {
-        Timer(const std::string& str = "untitled") :reportTitle{ str }
-        {
-            timeStart = std::chrono::system_clock::now();
-        }
+struct Timer
+{
+	Timer(const std::string& str = "untitled") : reportTitle{ str }
+	{
+		timeStart = std::chrono::system_clock::now();
+	}
 
-        ~Timer()
-        {
-            if (!reported)
-                report();
-        }
+	~Timer()
+	{
+		if (!reported)
+			report();
+	}
 
-        void report()
-        {
-            auto timeFinish = std::chrono::system_clock::now();
-            auto diff = timeFinish - timeStart;
-            std::cout << reportTitle << ": " << std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << "_ms\n";
-            reported = true;
-        }
-        std::chrono::system_clock::time_point timeStart;
-        std::string reportTitle = "";
-        bool reported = false;
-    };
-}
+	void report()
+	{
+		auto timeFinish = std::chrono::system_clock::now();
+		auto diff = timeFinish - timeStart;
+		std::cout << reportTitle << ": "
+							<< std::chrono::duration_cast<std::chrono::milliseconds>(diff).count() << "_ms\n";
+		reported = true;
+	}
+	std::chrono::system_clock::time_point timeStart;
+	std::string reportTitle = "";
+	bool reported = false;
+};
+}	 // namespace yrcu

--- a/Relativistic_Hash_Table/main.cpp
+++ b/Relativistic_Hash_Table/main.cpp
@@ -1,121 +1,129 @@
-#include <iostream>
-#include <future>
+#include <array>
+#include <cassert>
 #include <cstdlib>
+#include <future>
+#include <iostream>
+#include <memory>
 #include <random>
 #include <shared_mutex>
-#include <memory>
-#include "TestsAndExamples/RCUTests.h"
-#include "TestsAndExamples/RCUTableTests.h"
 
 #include "RCUApi.h"
 #include "RCUHashTableApi.h"
 #include "RCUHashTableTypes.h"
-#include <array>
-#include <cassert>
+#include "TestsAndExamples/RCUTableTests.h"
+#include "TestsAndExamples/RCUTests.h"
 
 namespace yrcu
 {
-    void rcuHashTableQuickExample()
-    {
-        RTable rTable;
-        rTableInit(rTable);
+void rcuHashTableQuickExample()
+{
+	RTable rTable;
+	rTableInit(rTable);
 
-        //user data to be tracked by the hash table
-        struct MyElement
-        {
-            int value;
-            //to be linked by the hash table
-            RNode entry;
-            bool valid;
-        };
+	// user data to be tracked by the hash table
+	struct MyElement
+	{
+		int value;
+		// to be linked by the hash table
+		RNode entry;
+		bool valid;
+	};
 
-        //insert all array elements into the hash table
-        std::vector<MyElement> myData {100000};
-        for (auto item = 0; item < myData.size(); ++item)
-        {
-            myData[item].value = static_cast<int>(item);
-            myData[item].valid = true;
-            auto hashVal = std::hash<int>{}(item);
-            bool inserted = rTableTryInsert(rTable, &myData[item].entry, hashVal, [](RNode* p1, RNode* p2)
-                {
-                    return YJ_CONTAINER_OF(p1, MyElement, entry)->value == YJ_CONTAINER_OF(p2, MyElement, entry)->value;
-                });
-            assert(inserted);
-        }
+	// insert all array elements into the hash table
+	std::vector<MyElement> myData{ 100000 };
+	for (auto item = 0; item < myData.size(); ++item)
+	{
+		myData[item].value = static_cast<int>(item);
+		myData[item].valid = true;
+		auto hashVal = std::hash<int>{}(item);
+		bool inserted = rTableTryInsert(
+				rTable,
+				&myData[item].entry,
+				hashVal,
+				[](RNode* p1, RNode* p2)
+				{
+					return YJ_CONTAINER_OF(p1, MyElement, entry)->value ==
+								 YJ_CONTAINER_OF(p2, MyElement, entry)->value;
+				});
+		assert(inserted);
+	}
 
-        //reader thread looks up
-        auto readerFunc = [&rTable, &myData]()
-        {
-            for (auto i = 0; i < myData.size(); ++i)
-            {
-                RTableReadLockGuard l(rTable);
-                auto hashVal = std::hash<int>{}(myData[i].value);
-                RNode* pEntry = rTableFind(rTable, hashVal, [i](const RNode* p)
-                    {
-                        return YJ_CONTAINER_OF(p, MyElement, entry)->value == i;
-                    });
-                //writer might erase elements that is not multiples of 8
-                //but other elements should remain found
-                if (i % 8 == 0)
-                {
-                    assert(pEntry);
-                    assert(pEntry == &myData[i].entry);
-                    assert(YJ_CONTAINER_OF(pEntry, MyElement, entry)->valid);
-                }
-            }
-        };
+	// reader thread looks up
+	auto readerFunc = [&rTable, &myData]()
+	{
+		for (auto i = 0; i < myData.size(); ++i)
+		{
+			RTableReadLockGuard l(rTable);
+			auto hashVal = std::hash<int>{}(myData[i].value);
+			RNode* pEntry = rTableFind(
+					rTable,
+					hashVal,
+					[i](const RNode* p) { return YJ_CONTAINER_OF(p, MyElement, entry)->value == i; });
+			// writer might erase elements that is not multiples of 8
+			// but other elements should remain found
+			if (i % 8 == 0)
+			{
+				assert(pEntry);
+				assert(pEntry == &myData[i].entry);
+				assert(YJ_CONTAINER_OF(pEntry, MyElement, entry)->valid);
+			}
+		}
+	};
 
-        //push reader threads
-        const auto nrThreads = std::thread::hardware_concurrency();
-        std::vector<std::future<void>> readerFutures{nrThreads};
-        for (auto& f : readerFutures)
-            f = std::async(std::launch::async, readerFunc);
+	// push reader threads
+	const auto nrThreads = std::thread::hardware_concurrency();
+	std::vector<std::future<void>> readerFutures{ nrThreads };
+	for (auto& f : readerFutures)
+		f = std::async(std::launch::async, readerFunc);
 
-        //a single writer removes and add back elements in several rounds
-        for (auto i = 0; i < myData.size(); ++i)
-        {
-            if (i % 8 == 0)
-                continue;
-            auto hash = std::hash<int>{}(myData[i].value);
+	// a single writer removes and add back elements in several rounds
+	for (auto i = 0; i < myData.size(); ++i)
+	{
+		if (i % 8 == 0)
+			continue;
+		auto hash = std::hash<int>{}(myData[i].value);
 
-            RNode* pEntry = rTableTryDetachAndSynchronize(rTable, hash, [val = myData[i].value](const RNode* p)
-                {return YJ_CONTAINER_OF(p, MyElement, entry)->value == val; }
-            );
-            assert(pEntry);
-            YJ_CONTAINER_OF(pEntry, MyElement, entry)->valid = false;
-        }
+		RNode* pEntry = rTableTryDetachAndSynchronize(
+				rTable,
+				hash,
+				[val = myData[i].value](const RNode* p)
+				{ return YJ_CONTAINER_OF(p, MyElement, entry)->value == val; });
+		assert(pEntry);
+		YJ_CONTAINER_OF(pEntry, MyElement, entry)->valid = false;
+	}
 
-        for (auto& f : readerFutures)
-            f.get();
-    }
-
-    void printRCUTable(RTable& rTable)
-    {
-        std::cout << "-------------------\n";
-        auto pBucket = rTable.core.pBucketsInfo.load();
-        for (auto iBucket = 0; iBucket < pBucket->nrBucketsPowerOf2; ++iBucket)
-        {
-            std::cout << "\nBucket " << iBucket << std::endl;
-            auto pSrc = pBucket->pBuckets + iBucket;
-
-            for (auto p = pSrc->list.next.load(std::memory_order_relaxed); p != nullptr; p = p->next.load(std::memory_order_relaxed))
-            {
-                size_t hashV = YJ_CONTAINER_OF(p, RNode, head)->hash;
-                std::cout << " hash: " << hashV;
-            }
-        }
-        std::cout << "\n-------------------\n";
-    }
+	for (auto& f : readerFutures)
+		f.get();
 }
+
+void printRCUTable(RTable& rTable)
+{
+	std::cout << "-------------------\n";
+	auto pBucket = rTable.core.pBucketsInfo.load();
+	for (auto iBucket = 0; iBucket < pBucket->nrBucketsPowerOf2; ++iBucket)
+	{
+		std::cout << "\nBucket " << iBucket << std::endl;
+		auto pSrc = pBucket->pBuckets + iBucket;
+
+		for (auto p = pSrc->list.next.load(std::memory_order_relaxed); p != nullptr;
+				 p = p->next.load(std::memory_order_relaxed))
+		{
+			size_t hashV = YJ_CONTAINER_OF(p, RNode, head)->hash;
+			std::cout << " hash: " << hashV;
+		}
+	}
+	std::cout << "\n-------------------\n";
+}
+}	 // namespace yrcu
 
 int main()
 {
-    //rcu zone tests
-    yrcu::rcuTests();
+	// rcu zone tests
+	yrcu::rcuTests();
 
-    //a quick example of the rcu hash table (rTable)
-    yrcu::rcuHashTableQuickExample();
+	// a quick example of the rcu hash table (rTable)
+	yrcu::rcuHashTableQuickExample();
 
-    //stress tests
-    yrcu::rTableTests();
+	// stress tests
+	yrcu::rTableTests();
 }


### PR DESCRIPTION
Split out the logic of atomic singly linked list so that it could be reused.

The atomic singly linked list itself could be useful, for example, when implementing a fixed bucket-count hash table.